### PR TITLE
Bugfix: form_documents column size

### DIFF
--- a/packages/database/migrations/20241031103354_form_documents_table.mjs
+++ b/packages/database/migrations/20241031103354_form_documents_table.mjs
@@ -8,7 +8,7 @@ export async function up(knex) {
     table.string('type').notNullable();
     table.string('file_name').notNullable();
     table.binary('data').notNullable();
-    table.string('extract').notNullable();
+    table.text('extract').notNullable();
   });
 }
 


### PR DESCRIPTION
Use TEXT column type for `extract` column in `form_documents` table, rather than a 255-character string.