### PR TITLE
Add command to recursively clean node_modules directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ To run tests in watch mode (except the `infra` tests, which use Jest):
 pnpm vitest
 ```
 
+If you start having unexplained build errors, the following commands are useful to clean up and start fresh.
+
+```bash
+pnpm clean:dist # removes previously built files recursively
+pnpm clean:modules # removes node_module directories recursively
+
+# ... run more commands like pnpm install and pnpm build after you have run these 
+```
+
+
 To start developing with hot reloading, use:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "turbo run build --filter=!@atj/infra-cdktf",
     "clean": "turbo run clean",
     "clean:modules": "find $(git rev-parse --show-toplevel) -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
+    "clean:dist": "find $(git rev-parse --show-toplevel) -name 'dist' -type d -prune -exec rm -rf '{}' +",
     "dev": "turbo run dev --concurrency 20",
     "format": "prettier --write \"packages/*/src/**/*.{js,jsx,ts,tsx,scss,css}\"",
     "lint": "turbo run lint",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "turbo run build --filter=!@atj/infra-cdktf",
     "clean": "turbo run clean",
+    "clean:modules": "find $(git rev-parse --show-toplevel) -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "dev": "turbo run dev --concurrency 20",
     "format": "prettier --write \"packages/*/src/**/*.{js,jsx,ts,tsx,scss,css}\"",
     "lint": "turbo run lint",


### PR DESCRIPTION
Uses git plumbing to add a command at the workspace root to clean modules since there have been times when we needed to do so.