### PR TITLE
Reusable Terraform Action

### DIFF
--- a/.github/workflows/_terraform-apply.yml
+++ b/.github/workflows/_terraform-apply.yml
@@ -6,11 +6,6 @@ on:
       deploy-env:
         type: string
         required: true
-      terraform_version:
-        description: Terraform version
-        required: false
-        default: "1.10.4"
-        type: string
 
 env:
   DEPLOY_ENV: ${{ inputs.deploy-env }}
@@ -55,23 +50,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - uses: actions/cache@v3
-        name: Check Cache for Terraform CLI
-        id: terraform-cache
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
         with:
-          path: /usr/local/bin/terraform
-          key: terraform-${{ inputs.terraform_version }}
-
-      - name: Install Terraform CLI
-        if: steps.terraform-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update && sudo apt-get install -y wget unzip
-          wget https://releases.hashicorp.com/terraform/${{ inputs.terraform_version }}/terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          unzip terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          sudo mv terraform /usr/local/bin/
-
-      - name: Verify Terraform Installation
-        run: terraform --version
+          terraform_version: "1.10.4"
 
       - name: Initialize Terraform CDK configuration
         shell: bash

--- a/.github/workflows/_terraform-apply.yml
+++ b/.github/workflows/_terraform-apply.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/_terraform-plan-pr-comment.yml
+++ b/.github/workflows/_terraform-plan-pr-comment.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Check Cache for Terraform CLI
         id: terraform-cache
         with:

--- a/.github/workflows/_terraform-plan-pr-comment.yml
+++ b/.github/workflows/_terraform-plan-pr-comment.yml
@@ -6,11 +6,6 @@ on:
       deploy-env:
         required: true
         type: string
-      terraform_version:
-        description: Terraform version
-        required: false
-        default: "1.10.4"
-        type: string
 
 jobs:
   terraform:
@@ -57,23 +52,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - uses: actions/cache@v4
-        name: Check Cache for Terraform CLI
-        id: terraform-cache
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
         with:
-          path: /usr/local/bin/terraform
-          key: terraform-${{ inputs.terraform_version }}
-
-      - name: Install Terraform CLI
-        if: steps.terraform-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update && sudo apt-get install -y wget unzip
-          wget https://releases.hashicorp.com/terraform/${{ inputs.terraform_version }}/terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          unzip terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          sudo mv terraform /usr/local/bin/
-
-      - name: Verify Terraform Installation
-        run: terraform --version
+          terraform_version: "1.10.4"
 
       - name: Initialize Terraform CDK configuration
         shell: bash

--- a/.github/workflows/_validate.yml
+++ b/.github/workflows/_validate.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: "1.48.1"
         type: string
-      terraform_version:
-        description: Terraform version
-        required: false
-        default: "1.10.4"
-        type: string
 
 jobs:
   run-tests:
@@ -97,23 +92,10 @@ jobs:
         shell: bash
         run: AUTH_SECRET=not-super-secret pnpm test:ci
 
-      - uses: actions/cache@v4
-        name: Check Cache for Terraform CLI
-        id: terraform-cache
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
         with:
-          path: /usr/local/bin/terraform
-          key: terraform-${{ inputs.terraform_version }}
-
-      - name: Install Terraform CLI
-        if: steps.terraform-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update && sudo apt-get install -y wget unzip
-          wget https://releases.hashicorp.com/terraform/${{ inputs.terraform_version }}/terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          unzip terraform_${{ inputs.terraform_version }}_linux_amd64.zip
-          sudo mv terraform /usr/local/bin/
-
-      - name: Verify Terraform Installation
-        run: terraform --version
+          terraform_version: "1.10.4"
 
       - name: Initialize Terraform CDK configuration
         shell: bash

--- a/.github/workflows/_validate.yml
+++ b/.github/workflows/_validate.yml
@@ -97,7 +97,7 @@ jobs:
         shell: bash
         run: AUTH_SECRET=not-super-secret pnpm test:ci
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Check Cache for Terraform CLI
         id: terraform-cache
         with:


### PR DESCRIPTION
We had discussed making the terraform install action reusable. However, there seems to be an issue where you can't have multiple uses in github actions where the call chain is file A -> uses file B -> uses file C without involving an artifact. This switches to use the Hashicorp-authored actions/setup-terraform which provides the artifact behavior and to gets around the structuring issue of our current action.

- update cache action to v4
- use setup-terraform action
