### PR TITLE
fix issue where pnpm test was not terminating on test completion

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 pnpm lint
 pnpm format
-pnpm test
+pnpm test:ci

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "turbo run lint",
     "pages": "rm -rf node_modules && npm i -g pnpm turbo && pnpm i && pnpm build && ln -sf ./apps/spotlight/dist _site",
     "test": "vitest run",
-    "test:ci": "vitest run # --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure",
+    "test:ci": "CI=true vitest run # --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure",
     "test:infra": "turbo run --filter=infra-cdktf test",
     "typecheck": "tsc --build --noEmit",
     "prepare": "husky"


### PR DESCRIPTION
Without the setting env var `CI`, the storybook browser tests kept the web socket connection open indefinitely, causing our pre-commit hooks to never exit and blocking commits unless we ran the commit command with --no-verify.

The `CI` var is set by default on the GH actions pipeline, but we need to set it explicitly for compatibility with local developer environments in the `test:ci` command.
