### PR TITLE
chore: add marco.pineda email to the user config

### DIFF
--- a/apps/server-doj/src/server.ts
+++ b/apps/server-doj/src/server.ts
@@ -21,6 +21,7 @@ export const createCustomServer = async (db: DatabaseContext): Promise<any> => {
         'emily.lordahl@gsa.gov',
         'khayal.alasgarov@gsa.gov',
         'jenny.richards@gsa.gov',
+        'marco.pineda@gsa.gov',
         // DOJ test users
         'deserene.h.worsley@usdoj.gov',
         'jordan.pendergrass@usdoj.gov',


### PR DESCRIPTION
This PR adds `marco.pineda@gsa.gov` to the User config.