### PR TITLE
feat: update radio-group and select-dropdown component UI

### DIFF
--- a/e2e/src/create.spec.ts
+++ b/e2e/src/create.spec.ts
@@ -41,7 +41,7 @@ test('Add questions', async ({ page }) => {
   // Create locators for both elements
   const fields = page.locator('.usa-label');
   const element1 = fields.filter({ hasText: 'Field label' });
-  const element2 = fields.filter({ hasText: 'Multiple choice question label' });
+  const element2 = fields.filter({ hasText: 'Question text' });
   expect(element1.first()).toBeTruthy();
   expect(element2.first()).toBeTruthy();
 

--- a/packages/common/src/locales/en/app.ts
+++ b/packages/common/src/locales/en/app.ts
@@ -65,13 +65,17 @@ export const en = {
     radioGroup: {
       ...defaults,
       displayName: 'Multiple choice question label',
-      fieldLabel: 'Multiple choice question label',
+      fieldLabel: 'Question text',
+      hintLabel: 'Hint Text (optional)',
+      hint: '',
       errorTextMustContainChar: 'String must contain at least 1 character(s)',
     },
     selectDropdown: {
       ...defaults,
-      displayName: 'Dropdown label',
-      fieldLabel: 'Dropdown label',
+      displayName: 'Question text',
+      fieldLabel: 'Question text',
+      hintLabel: 'Hint Text (optional)',
+      hint: '',
       errorTextMustContainChar: 'String must contain at least 1 character(s)',
     },
     dateOfBirth: {

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
@@ -7,11 +7,17 @@ import { type PatternComponent } from '../../../Form/index.js';
 
 export const RadioGroupPattern: PatternComponent<RadioGroupProps> = props => {
   const { register } = useFormContext();
+  const hintId = `hint-${props.groupId}`;
   return (
     <div className="usa-fieldset padding-top-2">
       <legend className="usa-legend text-bold margin-top-0 padding-top-3">
         {props.legend}
       </legend>
+      {props.hint && (
+        <div className="usa-hint" id={hintId}>
+          {props.hint}
+        </div>
+      )}
       {props.options.map((option, index) => {
         const id = option.id;
         return (

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
@@ -4,38 +4,51 @@ import { useFormContext } from 'react-hook-form';
 import { type RadioGroupProps } from '@gsa-tts/forms-core';
 
 import { type PatternComponent } from '../../../Form/index.js';
+import classNames from 'classnames';
 
 export const RadioGroupPattern: PatternComponent<RadioGroupProps> = props => {
   const { register } = useFormContext();
   const hintId = `hint-${props.groupId}`;
   return (
     <div className="usa-fieldset padding-top-2">
-      <legend className="usa-legend text-bold margin-top-0 padding-top-3">
-        {props.legend}
-      </legend>
-      {props.hint && (
-        <div className="usa-hint" id={hintId}>
-          {props.hint}
-        </div>
-      )}
-      {props.options.map((option, index) => {
-        const id = option.id;
-        return (
-          <div key={index} className="usa-radio">
-            <input
-              className="usa-radio__input"
-              type="radio"
-              id={`input-${id}`}
-              {...register(`${props.groupId}`)}
-              value={option.id}
-              defaultChecked={option.defaultChecked}
-            />
-            <label htmlFor={`input-${id}`} className="usa-radio__label">
-              {option.label}
-            </label>
+      <div
+        className={classNames('usa-form-group margin-top-2', {
+          'usa-form-group--error': props.error,
+        })}
+      >
+        <legend className="usa-legend text-bold margin-top-0">
+          {props.legend}
+          {props.required && <span className="usa-required">*</span>}
+        </legend>
+        {props.hint && (
+          <div className="usa-hint" id={hintId}>
+            {props.hint}
           </div>
-        );
-      })}
+        )}
+        {props.error && (
+          <div className="usa-error-message" id={`error-${props.groupId}`}>
+            {props.error.message}
+          </div>
+        )}
+        {props.options.map((option, index) => {
+          const id = option.id;
+          return (
+            <div key={index} className="usa-radio">
+              <input
+                className="usa-radio__input"
+                type="radio"
+                id={`input-${id}`}
+                {...register(`${props.groupId}`)}
+                value={option.id}
+                defaultChecked={option.defaultChecked}
+              />
+              <label htmlFor={`input-${id}`} className="usa-radio__label">
+                {option.label}
+              </label>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/packages/design/src/Form/components/SelectDropdown/SelectDropdown.tsx
+++ b/packages/design/src/Form/components/SelectDropdown/SelectDropdown.tsx
@@ -7,6 +7,7 @@ import { type PatternComponent } from '../../index.js';
 export const SelectDropdownPattern: PatternComponent<SelectDropdownProps> = ({
   selectId,
   label,
+  hint,
   required,
   options,
   error,
@@ -14,6 +15,7 @@ export const SelectDropdownPattern: PatternComponent<SelectDropdownProps> = ({
 }) => {
   const { register } = useFormContext();
   const errorId = `input-error-message-${selectId}`;
+  const hintId = `hint-${selectId}`;
 
   return (
     <div className="usa-fieldset padding-top-2">
@@ -31,6 +33,11 @@ export const SelectDropdownPattern: PatternComponent<SelectDropdownProps> = ({
           {label}
           {required && <span className="required-indicator">*</span>}
         </label>
+        {hint && (
+          <div className="usa-hint" id={hintId}>
+            {hint}
+          </div>
+        )}
         {error && (
           <div className="usa-error-message" id={errorId} role="alert">
             {error.message}

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
@@ -14,11 +14,13 @@ const pattern: RadioGroupPattern = {
   type: 'radio-group',
   data: {
     label: message.patterns.radioGroup.displayName,
+    hint: message.patterns.radioGroup.hint,
     options: [
       { label: 'Option 1', id: 'option-1' },
       { label: 'Option 2', id: 'option-2' },
       { label: 'Option 3', id: 'option-3' },
     ],
+    required: false,
   },
 };
 
@@ -70,7 +72,7 @@ export const AddField: StoryObj<typeof FormEdit> = {
 
     await userEvent.click(
       canvas.getByRole('button', {
-        name: /add new/i,
+        name: /add option/i,
       })
     );
 

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -41,14 +41,16 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
     usePatternEditFormContext<RadioGroupPattern>(pattern.id);
   const [options, setOptions] = useState(pattern.data.options);
   const label = getFieldState('label');
+  const hint = getFieldState('hint');
 
   return (
     <div className="grid-row grid-gap">
-      <div className="tablet:grid-col-6 mobile-lg:grid-col-12 margin-bottom-2">
+      <div className="mobile-lg:grid-col-12 margin-bottom-2">
         <label
           className={classnames('usa-label', {
             'usa-label--error': label.error,
-          })}
+          }, `${styles.patternChoiceFieldWrapper}`)}
+          htmlFor={fieldId('label')}
         >
           {message.patterns.radioGroup.fieldLabel}
           {label.error ? (
@@ -57,13 +59,41 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
             </span>
           ) : null}
           <input
-            className="usa-input"
+            className={`usa-input ${styles.patternChoiceFieldWrapper}`}
             id={fieldId('label')}
             defaultValue={pattern.data.label}
             {...register('label')}
             type="text"
             autoFocus
           ></input>
+        </label>
+      </div>
+      <div className="mobile-lg:grid-col-12 margin-bottom-2">
+        <label
+          className={classnames(
+            'usa-label',
+            {
+              'usa-label--error': hint.error,
+            },
+            `${styles.patternChoiceFieldWrapper}`
+          )}
+          htmlFor={fieldId('hint')}
+        >
+          <span className={`${styles.secondaryColor}`}>
+            {message.patterns.radioGroup.hintLabel}
+          </span>
+          {hint.error ? (
+            <span className="usa-error-message" role="alert">
+              {hint.error.message}
+            </span>
+          ) : null}
+          <input
+            className={`usa-input ${styles.patternChoiceFieldWrapper}`}
+            id={fieldId('hint')}
+            defaultValue={pattern.data.hint}
+            {...register('hint')}
+            type="text"
+          />
         </label>
       </div>
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
@@ -92,6 +122,10 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
                   defaultValue={option.id}
                   aria-label={`Option ${index + 1} id`}
                 />
+                <label
+                  htmlFor={`options-${index}.id`}
+                  className={`usa-radio__label ${styles.optionCircle}`}
+                ></label>
                 <input
                   className="usa-input"
                   id={fieldId(`options.${index}.label`)}
@@ -104,19 +138,37 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
           );
         })}
         <button
-          className="usa-button usa-button--outline margin-top-1"
+          className={`usa-link ${styles.addMorePatternButton}`}
           type="button"
           onClick={event => {
             event.preventDefault();
             const optionId = `option-${options.length + 1}`;
-            setOptions(options.concat({ id: optionId, label: optionId }));
+            setOptions(options.concat({ id: optionId, label: `Option ${options.length + 1}`}));
           }}
         >
-          Add new
+          Add option
         </button>
       </div>
       <div className="grid-col-12">
-        <PatternEditActions />
+      <PatternEditActions>
+          <span className="usa-checkbox">
+            <input
+              style={{ display: 'inline-block' }}
+              className="usa-checkbox__input bg-primary-lighter"
+              type="checkbox"
+              id={fieldId('required')}
+              {...register('required')}
+              defaultChecked={pattern.data.required}
+            />
+            <label
+              style={{ display: 'inline-block' }}
+              className="usa-checkbox__label"
+              htmlFor={fieldId('required')}
+            >
+              Required
+            </label>
+          </span>
+        </PatternEditActions>
       </div>
     </div>
   );

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -47,9 +47,13 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
     <div className="grid-row grid-gap">
       <div className="mobile-lg:grid-col-12 margin-bottom-2">
         <label
-          className={classnames('usa-label', {
-            'usa-label--error': label.error,
-          }, `${styles.patternChoiceFieldWrapper}`)}
+          className={classnames(
+            'usa-label',
+            {
+              'usa-label--error': label.error,
+            },
+            `${styles.patternChoiceFieldWrapper}`
+          )}
           htmlFor={fieldId('label')}
         >
           {message.patterns.radioGroup.fieldLabel}
@@ -143,14 +147,19 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
           onClick={event => {
             event.preventDefault();
             const optionId = `option-${options.length + 1}`;
-            setOptions(options.concat({ id: optionId, label: `Option ${options.length + 1}`}));
+            setOptions(
+              options.concat({
+                id: optionId,
+                label: `Option ${options.length + 1}`,
+              })
+            );
           }}
         >
           Add option
         </button>
       </div>
       <div className="grid-col-12">
-      <PatternEditActions>
+        <PatternEditActions>
           <span className="usa-checkbox">
             <input
               style={{ display: 'inline-block' }}

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
@@ -72,7 +72,7 @@ export const AddField: StoryObj<typeof FormEdit> = {
 
     await userEvent.click(
       canvas.getByRole('button', {
-        name: /add new/i,
+        name: /add option/i,
       })
     );
 

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -42,14 +42,15 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
     usePatternEditFormContext<SelectDropdownPattern>(pattern.id);
   const [options, setOptions] = useState(pattern.data.options);
   const label = getFieldState('label');
+  const hint = getFieldState('hint');
 
   return (
     <div className="grid-row grid-gap">
-      <div className="tablet:grid-col-6 mobile-lg:grid-col-12 margin-bottom-2">
+      <div className="mobile-lg:grid-col-12 margin-bottom-2">
         <label
           className={classnames('usa-label', {
             'usa-label--error': label.error,
-          })}
+          }, `${styles.patternChoiceFieldWrapper}`)}
         >
           {message.patterns.selectDropdown.fieldLabel}
           {label.error ? (
@@ -58,12 +59,39 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
             </span>
           ) : null}
           <input
-            className="usa-input"
+            className={`usa-input ${styles.patternChoiceFieldWrapper}`}
             id={fieldId('label')}
             defaultValue={pattern.data.label}
             {...register('label')}
             type="text"
             autoFocus
+          ></input>
+        </label>
+      </div>
+      <div className="mobile-lg:grid-col-12 margin-bottom-2">
+        <label
+          className={classnames(
+            'usa-label',
+            {
+              'usa-label--error': label.error,
+            },
+            `${styles.patternChoiceFieldWrapper}`
+          )}
+        >
+          <span className={`${styles.secondaryColor}`}>
+            {message.patterns.radioGroup.hintLabel}
+          </span>
+          {hint.error ? (
+            <span className="usa-error-message" role="alert">
+              {hint.error.message}
+            </span>
+          ) : null}
+          <input
+            className={`usa-input ${styles.patternChoiceFieldWrapper}`}
+            id={fieldId('hint')}
+            defaultValue={pattern.data.hint}
+            {...register('hint')}
+            type="text"
           ></input>
         </label>
       </div>
@@ -93,6 +121,10 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
                   defaultValue={option.value}
                   aria-label={`Option ${index + 1} value`}
                 />
+                <label
+                  htmlFor={`options-${index}.id`}
+                  className={`usa-radio__label ${styles.optionCircle}`}
+                ></label>
                 <input
                   className="usa-input"
                   id={fieldId(`options.${index}.label`)}
@@ -109,12 +141,12 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
           type="button"
           onClick={event => {
             event.preventDefault();
-            const optionId = `option-${options.length + 1}`;
+            const optionLabel = `Option ${options.length + 1}`;
             const optionValue = `value-${options.length + 1}`;
-            setOptions(options.concat({ value: optionValue, label: optionId }));
+            setOptions(options.concat({ value: optionValue, label: optionLabel }));
           }}
         >
-          Add new
+          Add option
         </button>
       </div>
       <div className="grid-col-12">

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -48,9 +48,13 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
     <div className="grid-row grid-gap">
       <div className="mobile-lg:grid-col-12 margin-bottom-2">
         <label
-          className={classnames('usa-label', {
-            'usa-label--error': label.error,
-          }, `${styles.patternChoiceFieldWrapper}`)}
+          className={classnames(
+            'usa-label',
+            {
+              'usa-label--error': label.error,
+            },
+            `${styles.patternChoiceFieldWrapper}`
+          )}
         >
           {message.patterns.selectDropdown.fieldLabel}
           {label.error ? (
@@ -143,7 +147,9 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
             event.preventDefault();
             const optionLabel = `Option ${options.length + 1}`;
             const optionValue = `value-${options.length + 1}`;
-            setOptions(options.concat({ value: optionValue, label: optionLabel }));
+            setOptions(
+              options.concat({ value: optionValue, label: optionLabel })
+            );
           }}
         >
           Add option

--- a/packages/design/src/FormManager/FormEdit/formEditStyles.module.css
+++ b/packages/design/src/FormManager/FormEdit/formEditStyles.module.css
@@ -1,5 +1,9 @@
 /* Add a Pattern Menu */
 
+.secondaryColor {
+  color: #757575;
+}
+
 .dropdownMenu {
   min-width: 315px;
   max-height: 19.688rem;
@@ -107,6 +111,14 @@
   background: none;
 }
 
+.optionCircle {
+  margin-top: 1.2rem;
+}
+
+.optionCircle:before {
+  box-shadow: 0 0 0 2px #a9aeb1;
+}
+
 .dottedLine {
   display: flex;
   align-items: center;
@@ -126,6 +138,10 @@
 
 .dottedLine::after {
   margin: 0 0 0 1em;
+}
+
+.patternChoiceFieldWrapper {
+  max-width: 100%;
 }
 
 /* Move to Page */
@@ -190,6 +206,16 @@
 
 .movePatternButton svg {
   font-size: 1.5rem;
+}
+
+.addMorePatternButton {
+  background-color: transparent;
+  border: none;
+  padding-left: 0;
+}
+
+.addMorePatternButton:focus {
+  outline: none !important;
 }
 
 @media (min-width: 64.5em) {

--- a/packages/forms/src/builder/builder.test.ts
+++ b/packages/forms/src/builder/builder.test.ts
@@ -301,10 +301,12 @@ describe('form builder', () => {
           id: 'radio-group-1',
           data: {
             label: 'Multiple choice question label',
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         },
         [newPattern.id]: {
@@ -382,10 +384,12 @@ describe('form builder', () => {
           id: 'radio-group-1',
           data: {
             label: 'Multiple choice question label',
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         },
         [newPattern.id]: {
@@ -465,10 +469,12 @@ describe('form builder', () => {
           id: 'radio-group-1',
           data: {
             label: 'Multiple choice question label',
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         },
         [newPattern.id]: {
@@ -544,10 +550,12 @@ describe('form builder', () => {
           id: 'radio-group-1',
           data: {
             label: 'Multiple choice question label',
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         },
         [newPattern.id]: {
@@ -557,10 +565,12 @@ describe('form builder', () => {
             label: expect.stringMatching(
               /^\(\s*Copy\s+\d{1,2}\/\d{1,2}\/\d{4},\s+\d{1,2}:\d{2}:\d{2}\s+[AP]M\)\s*Multiple choice question label/
             ),
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         },
       },
@@ -776,10 +786,12 @@ export const createTestBlueprintMultipleFieldsets = () => {
           id: 'radio-group-1',
           data: {
             label: 'Multiple choice question label',
+            hint: '',
             options: [
               { id: 'option-1', label: 'Option 1' },
               { id: 'option-2', label: 'Option 2' },
             ],
+            required: false,
           },
         } satisfies RadioGroupPattern,
       ],

--- a/packages/forms/src/components.ts
+++ b/packages/forms/src/components.ts
@@ -150,6 +150,7 @@ export type SelectDropdownProps = PatternProps<{
     label: string;
   }[];
   label: string;
+  hint?: string;
   required: boolean;
   error?: FormError;
   value?: string;

--- a/packages/forms/src/components.ts
+++ b/packages/forms/src/components.ts
@@ -130,12 +130,16 @@ export type RadioGroupProps = PatternProps<{
   type: 'radio-group';
   groupId: string;
   legend: string;
+  label: string;
+  hint?: string;
   options: {
     id: string;
     name: string;
     label: string;
     defaultChecked: boolean;
   }[];
+  required: boolean;
+  error?: FormError;
 }>;
 
 export type SelectDropdownProps = PatternProps<{

--- a/packages/forms/src/documents/pdf/parsing-api.ts
+++ b/packages/forms/src/documents/pdf/parsing-api.ts
@@ -224,12 +224,14 @@ export const processApiResponse = async (json: any): Promise<ParsedPdf> => {
         'radio-group',
         {
           label: element.legend,
+          hint: '',
           options: element.options.map(option => ({
             id: option.id,
             label: option.label,
             name: option.name,
             defaultChecked: option.default_checked,
           })),
+          required: false,
         }
       );
       if (radioGroupPattern) {

--- a/packages/forms/src/patterns/radio-group.ts
+++ b/packages/forms/src/patterns/radio-group.ts
@@ -10,6 +10,8 @@ import { safeZodParseFormErrors } from '../util/zod.js';
 
 const configSchema = z.object({
   label: z.string().min(1),
+  hint: z.string().optional(),
+  required: z.boolean(),
   options: z
     .object({
       id: z.string().regex(/^[A-Za-z][A-Za-z0-9\-_:.]*$/, 'Invalid Option ID'),
@@ -28,10 +30,12 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
     iconPath: 'radio-options-icon.svg',
     initial: {
       label: 'Multiple choice question label',
+      hint: '',
       options: [
         { id: 'option-1', label: 'Option 1' },
         { id: 'option-2', label: 'Option 2' },
       ],
+      required: false,
     },
     parseUserInput: (pattern, input: unknown) => {
       // FIXME: Not sure why we're sometimes getting a string here, and sometimes
@@ -80,6 +84,7 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
           type: 'radio-group',
           groupId: pattern.id,
           legend: pattern.data.label,
+          hint: pattern.data.hint,
           options: pattern.data.options.map(option => {
             const optionId = createId(pattern.id, option.id);
             return {
@@ -90,6 +95,7 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
             };
           }),
           error: sessionError,
+          required: pattern.data.required,
         } as RadioGroupProps,
         children: [],
       };

--- a/packages/forms/src/patterns/radio-group.ts
+++ b/packages/forms/src/patterns/radio-group.ts
@@ -38,34 +38,27 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
       required: false,
     },
     parseUserInput: (pattern, input: unknown) => {
-      // FIXME: Not sure why we're sometimes getting a string here, and sometimes
-      // the expected object. Workaround, by accepting both.
       if (typeof input === 'string') {
         return {
           success: true,
           data: input,
         };
       }
-      const optionId = getSelectedOption(pattern, input);
-      return {
-        success: true,
-        data: optionId || '',
-      };
-      /*
-      if (optionId) {
+
+      if (pattern.data.required) {
         return {
-          success: true,
-          data: optionId,
+          success: false,
+          error: {
+            type: 'custom',
+            message: 'No option selected for radio group',
+          },
         };
       }
+
       return {
-        success: false,
-        error: {
-          type: 'custom',
-          message: `No option selected for radio group: ${pattern.id}. Input: ${input}`,
-        },
+        success: true,
+        data: '',
       };
-      */
     },
     parseConfigData: obj => {
       const result = safeZodParseFormErrors(configSchema, obj);
@@ -104,19 +97,6 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
 
 const createId = (groupId: string, optionId: string) =>
   `${groupId}.${optionId}`;
-
-const getSelectedOption = (pattern: RadioGroupPattern, input: unknown) => {
-  if (!input) {
-    return;
-  }
-  const inputMap = input as Record<string, 'on' | null>;
-  const optionIds = pattern.data.options
-    .filter(option => inputMap[option.id] === 'on')
-    .map(option => option.id);
-  if (optionIds.length === 1) {
-    return optionIds[0];
-  }
-};
 
 export const extractOptionId = (
   groupId: string,

--- a/packages/forms/src/patterns/select-dropdown/select-dropdown.ts
+++ b/packages/forms/src/patterns/select-dropdown/select-dropdown.ts
@@ -11,6 +11,7 @@ import {
 const configSchema = z.object({
   label: z.string().min(1),
   required: z.boolean(),
+  hint: z.string().optional(),
   options: z
     .object({
       value: z
@@ -67,9 +68,9 @@ export const selectDropdownConfig: PatternConfig<
     label: 'Dropdown-label',
     required: false,
     options: [
-      { value: 'value1', label: 'Option-1' },
-      { value: 'value2', label: 'Option-2' },
-      { value: 'value3', label: 'Option-3' },
+      { value: 'value1', label: 'Option 1' },
+      { value: 'value2', label: 'Option 2' },
+      { value: 'value3', label: 'Option 3' },
     ],
   },
 
@@ -97,6 +98,7 @@ export const selectDropdownConfig: PatternConfig<
         _patternId: pattern.id,
         type: 'select-dropdown',
         label: pattern.data.label,
+        hint: pattern.data.hint,
         selectId: pattern.id,
         options: pattern.data.options.map(option => {
           return {


### PR DESCRIPTION
**Overview**
Updated the choice component UI for `radio-group`, `select-dropdown`.

**Key Changes**
> Adds hint field and required field for components
> Updates Copy for choice component fields
> Refactors the UI to reflect the hint and required fields in components.
> Refactors the choice schema to account for options
> Adds styles for Figma parity
> Updates Tests

**Figma Reference**
https://www.figma.com/design/RAm1GWbVTdBpzlmaLL6pLO/Forms-Platform?node-id=3198-21604&p=f&t=RXcqnhASJeRwxx5u-0

**Ticket Reference**
These changes are part of the https://github.com/GSA-TTS/forms/issues/454.

**Note**:
Checkbox changes will be done in separate ticket