### PR TITLE
Add DOJ demo header and footer to server app

### DIFF
--- a/packages/server/src/components/DOJFooter.astro
+++ b/packages/server/src/components/DOJFooter.astro
@@ -1,0 +1,159 @@
+---
+import { Image } from 'astro:assets';
+import * as routes from '../routes';
+import { getServerContext } from '../config/astro.js';
+
+const { baseUrl } = await getServerContext(Astro);
+
+---
+<style>
+    .usa-footer {
+      border-top: 3px solid #ffbe2e;
+      background-color: #171716;
+    }
+    
+    .footer-text {
+      color: #ffbe2e;
+    }
+    
+    .usa-link,
+    .usa-link:visited  {
+      color: #fff;
+    }
+    .usa-link:hover {
+      color: #ffbe2e;
+    }    
+</style>
+
+<footer id="footer" class="usa-footer">
+    <div class="usa-identifier usa-footer__primary padding-bottom-0">
+      <div class="grid-container usa-footer__primary-content maxw-desktop">
+        <div class="grid-row padding-top-0 padding-bottom-3 flex-justify-center">
+          <div>
+            <section
+              aria-label="Agency identifier,"
+              class="usa-identifier__section usa-identifier__section--masthead"
+            >
+              <div class="align-center display-flex maxw-desktop">
+                <div class="usa-identifier__logos padding-bottom-3">
+                  <a
+                    href="https://www.justice.gov/pardon"
+                    class="usa-identifier__logo"
+                  >
+                    <Image
+                      src=`https://www.justice.gov/themes/custom/usdoj_uswds/images/doj-main-header-logo.svg`
+                      alt="U.S. Department of Justice seal"
+                      width="300"
+                      height="100"
+                    />
+                  </a>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+        <nav
+          aria-label="Important links,"
+          class="usa-identifier__section usa-identifier__section--required-links"
+        >
+          <div class="align-center display-flex maxw-desktop">
+            <ul class="usa-identifier__required-links-list">
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.justice.gov/about"
+                  class="usa-identifier__required-link usa-link"
+                  >About</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.justice.gov/jmd/vulnerability-disclosure-policy"
+                  class="usa-identifier__required-link usa-link"
+                  >Vulnerability Disclosure Policy</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.justice.gov/accessibility/accessibility-statement"
+                  class="usa-identifier__required-link usa-link"
+                  >Accessibility statement</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.justice.gov/oip"
+                  class="usa-identifier__required-link usa-link"
+                  >FOIA requests</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.justice.gov/jmd/eeo-program-status-report"
+                  class="usa-identifier__required-link usa-link"
+                  >No FEAR Act data</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.gsaig.gov/"
+                  class="usa-identifier__required-link usa-link"
+                  >Office of the Inspector General</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://www.gsa.gov/reference/reports/budget-performance"
+                  class="usa-identifier__required-link usa-link"
+                  >Performance reports</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="/privacy-policy/"
+                  class="usa-identifier__required-link usa-link"
+                  >Privacy policy</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="mailto:10x@gsa.gov"
+                  class="usa-identifier__required-link usa-link"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  >Email Us</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href="https://github.com/GSA-TTS/forms"
+                  class="usa-identifier__required-link usa-link"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  >Github</a
+                >
+              </li>
+              <li class="usa-identifier__required-links-item">
+                <a
+                  href={routes.getStorybookUrl(baseUrl)}
+                  class="usa-identifier__required-link usa-link"
+                >
+                  Storybook
+                </a>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </div>
+      <section
+        aria-label="U.S. government information and services,"
+        class="usa-identifier__section usa-identifier__section--usagov margin-top-105 padding-bottom-105 maxw-desktop grid-container"
+      >
+          <div class="align-center display-flex maxw-desktop">
+            <div class="usa-identifier__usagov-description footer-text">
+              Looking for U.S. government information and services?&nbsp;
+            </div>
+            <a href="https://www.usa.gov/" class="usa-link">Contact USA.gov</a>
+          </div>
+      </section>
+    </div>
+  </footer>

--- a/packages/server/src/components/DOJFooter.astro
+++ b/packages/server/src/components/DOJFooter.astro
@@ -4,7 +4,6 @@ import * as routes from '../routes';
 import { getServerContext } from '../config/astro.js';
 
 const { baseUrl } = await getServerContext(Astro);
-
 ---
 <style>
     .usa-footer {

--- a/packages/server/src/components/DOJHeader.astro
+++ b/packages/server/src/components/DOJHeader.astro
@@ -1,0 +1,40 @@
+---
+import { getServerContext } from '../config/astro.js';
+import * as routes from '../routes';
+
+const { baseUrl } = await getServerContext(Astro);
+---
+<style>
+    .doj-background {
+      background-color: #162e51;
+      border-bottom: 3px solid #ffbe2e;
+    }
+    
+    .doj-logo {
+      width: 350px;
+      height: 90px;
+    }
+    
+    @media (max-width: 63.99em) {
+      .doj-logo {width: 100px; height: 40px;}
+    }
+</style>
+
+<div class="doj-background">
+    <div class="usa-navbar">
+      <div class="usa-logo float-left site-logo">
+        <em class="usa-logo__text">
+            <a href={routes.getHomeUrl(baseUrl)} title="10x Forms Platform">
+                <img
+                  src="https://www.justice.gov/d9/2023-07/doj-logo-pardon.svg"
+                  loading="eager"
+                  decoding="sync"
+                  alt="DOJ Logo Pardon"
+                  class="doj-logo"
+                />
+              </a>
+        </em>
+      </div>
+      <button type="button" class="usa-menu-btn">Menu</button>
+    </div>
+</div>

--- a/packages/server/src/components/Footer.astro
+++ b/packages/server/src/components/Footer.astro
@@ -2,9 +2,14 @@
 import { getBranchTreeUrl } from '../lib/github';
 
 import { getServerContext } from '../config/astro.js';
+import DOJFooter from './DOJFooter.astro';
 const { github } = await getServerContext(Astro);
+const isForm = Astro.url.href.includes('/forms/');
 ---
 
+{ isForm ? (
+  <DOJFooter />
+) : ( 
 <footer class="usa-footer usa-footer--slim">
   <div class="grid-container usa-footer__return-to-top">
     <a href="#">Return to top</a>
@@ -37,3 +42,4 @@ const { github } = await getServerContext(Astro);
     </div>
   </div>
 </footer>
+)}

--- a/packages/server/src/components/Footer.astro
+++ b/packages/server/src/components/Footer.astro
@@ -3,6 +3,7 @@ import { getBranchTreeUrl } from '../lib/github';
 
 import { getServerContext } from '../config/astro.js';
 import DOJFooter from './DOJFooter.astro';
+
 const { github } = await getServerContext(Astro);
 const isForm = Astro.url.href.includes('/forms/');
 ---

--- a/packages/server/src/components/Header.astro
+++ b/packages/server/src/components/Header.astro
@@ -4,6 +4,7 @@ import logoSvg from '@gsa-tts/forms-design/images/logo.svg';
 
 import { getServerContext, getUserSession } from '../config/astro.js';
 import * as routes from '../routes';
+import DOJHeader from './DOJHeader.astro';
 
 const { baseUrl, title } = await getServerContext(Astro);
 
@@ -16,6 +17,7 @@ const getNavLinkClasses = (url: string) => {
 };
 
 const { session } = getUserSession(Astro);
+const isForm = Astro.url.href.includes('/forms/');
 ---
 
 <div class="usa-overlay"></div>
@@ -26,6 +28,9 @@ const { session } = getUserSession(Astro);
       the public.</span
     >
   </div>
+  {isForm ? (
+    <DOJHeader />
+  ) : (
   <div class="bg-base-darkest">
     <div class="usa-navbar">
       <div class="usa-logo">
@@ -39,6 +44,7 @@ const { session } = getUserSession(Astro);
       <button type="button" class="usa-menu-btn">Menu</button>
     </div>
   </div>
+  )}
   <nav aria-label="Primary navigation" class="usa-nav">
     <div class="usa-nav__inner">
       <button type="button" class="usa-nav__close">


### PR DESCRIPTION
**Overview**
This PR adds the DOJ demo header and footer to the server app

**Screen shots**
Desktop:
![Screenshot 2025-03-21 at 11 30 38 AM](https://github.com/user-attachments/assets/48eba58b-7f74-4efa-ade5-5ed3944a0bdb)

Mobile:
![Screenshot 2025-03-21 at 11 31 50 AM](https://github.com/user-attachments/assets/b63af283-8b86-42d8-a55f-4b6bec3db847)
