### PR TITLE
refactor: adds custom choice option hook for option delete and update label

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -10,7 +10,10 @@ import { PatternEditComponent } from '../../types.js';
 import { PatternEditActions } from '../common/PatternEditActions.js';
 import { PatternOptionActions } from '../common/PatternOptionActions.js';
 import { PatternEditForm } from '../common/PatternEditForm.js';
-import { createPatternOptionsWithContext, usePatternEditFormContext } from '../common/hooks.js';
+import {
+  createPatternOptionsWithContext,
+  usePatternEditFormContext,
+} from '../common/hooks.js';
 import { enLocale as message } from '@gsa-tts/forms-common';
 import styles from '../../formEditStyles.module.css';
 
@@ -40,7 +43,8 @@ const RadioGroupPatternEdit: PatternEditComponent<RadioGroupProps> = ({
 const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
   const { fieldId, getFieldState, register } =
     usePatternEditFormContext<RadioGroupPattern>(pattern.id);
-  const { options, setOptions, deleteOption, updateOptionLabel } = createPatternOptionsWithContext(pattern);
+  const { options, setOptions, deleteOption, updateOptionLabel } =
+    createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
 

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import { type RadioGroupProps } from '@gsa-tts/forms-core';
 import { type RadioGroupPattern } from '@gsa-tts/forms-core';
@@ -10,7 +10,7 @@ import { PatternEditComponent } from '../../types.js';
 import { PatternEditActions } from '../common/PatternEditActions.js';
 import { PatternOptionActions } from '../common/PatternOptionActions.js';
 import { PatternEditForm } from '../common/PatternEditForm.js';
-import { usePatternEditFormContext } from '../common/hooks.js';
+import { createPatternOptionsWithContext, usePatternEditFormContext } from '../common/hooks.js';
 import { enLocale as message } from '@gsa-tts/forms-common';
 import styles from '../../formEditStyles.module.css';
 
@@ -38,26 +38,11 @@ const RadioGroupPatternEdit: PatternEditComponent<RadioGroupProps> = ({
 };
 
 const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
-  const { fieldId, getFieldState, register, setValue } =
+  const { fieldId, getFieldState, register } =
     usePatternEditFormContext<RadioGroupPattern>(pattern.id);
-  const [options, setOptions] = useState(() => [...pattern.data.options]);
+  const { options, setOptions, deleteOption, updateOptionLabel } = createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
-
-  const handleOptionLabelChange = (index: number, value: string) => {
-    const newOptions = [...options];
-    newOptions[index].label = value;
-    setOptions(newOptions);
-  };
-
-  const handleDeleteOption = (optionId: string) => {
-    const newOptions = options.filter(o => o.id !== optionId);
-    setOptions(newOptions);
-  };
-
-  useEffect(() => {
-    setValue(`options`, options);
-  }, [options, setValue]);
 
   return (
     <div className="grid-row grid-gap">
@@ -151,12 +136,12 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
                   id={fieldId(`options.${index}.label`)}
                   {...register(`options.${index}.label`)}
                   value={option.label}
-                  onChange={e => handleOptionLabelChange(index, e.target.value)}
+                  onChange={e => updateOptionLabel(index, e.target.value)}
                   aria-label={`Option ${index + 1} label`}
                 />
                 <PatternOptionActions
                   optionId={option.id}
-                  onDelete={handleDeleteOption}
+                  onDelete={deleteOption}
                 />
               </div>
             </div>

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import { type SelectDropdownProps } from '@gsa-tts/forms-core';
 import { type SelectDropdownPattern } from '@gsa-tts/forms-core';
@@ -10,7 +10,7 @@ import { PatternEditComponent } from '../../types.js';
 import { PatternEditActions } from '../common/PatternEditActions.js';
 import { PatternOptionActions } from '../common/PatternOptionActions.js';
 import { PatternEditForm } from '../common/PatternEditForm.js';
-import { usePatternEditFormContext } from '../common/hooks.js';
+import { usePatternEditFormContext, createPatternOptionsWithContext } from '../common/hooks.js';
 import { enLocale as message } from '@gsa-tts/forms-common';
 import styles from '../../formEditStyles.module.css';
 
@@ -39,26 +39,11 @@ const SelectDropdownPatternEdit: PatternEditComponent<SelectDropdownProps> = ({
 };
 
 const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
-  const { fieldId, getFieldState, register, setValue } =
+  const { fieldId, getFieldState, register } =
     usePatternEditFormContext<SelectDropdownPattern>(pattern.id);
-  const [options, setOptions] = useState(pattern.data.options);
+  const { options, setOptions, deleteOption, updateOptionLabel } = createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
-
-  const handleOptionLabelChange = (index: number, value: string) => {
-    const newOptions = [...options];
-    newOptions[index].label = value;
-    setOptions(newOptions);
-  };
-
-  const handleDeleteOption = (optionId: string) => {
-    const newOptions = options.filter(o => o.id !== optionId);
-    setOptions(newOptions);
-  };
-
-  useEffect(() => {
-    setValue(`options`, options);
-  }, [options, setValue]);
 
   return (
     <div className="grid-row grid-gap">
@@ -150,12 +135,12 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
                   id={fieldId(`options.${index}.label`)}
                   {...register(`options.${index}.label`)}
                   value={option.label}
-                  onChange={e => handleOptionLabelChange(index, e.target.value)}
+                  onChange={e => updateOptionLabel(index, e.target.value)}
                   aria-label={`Option ${index + 1} label`}
                 />
                 <PatternOptionActions
                   optionId={option.id}
-                  onDelete={handleDeleteOption}
+                  onDelete={deleteOption}
                 />
               </div>
             </div>

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -10,7 +10,10 @@ import { PatternEditComponent } from '../../types.js';
 import { PatternEditActions } from '../common/PatternEditActions.js';
 import { PatternOptionActions } from '../common/PatternOptionActions.js';
 import { PatternEditForm } from '../common/PatternEditForm.js';
-import { usePatternEditFormContext, createPatternOptionsWithContext } from '../common/hooks.js';
+import {
+  usePatternEditFormContext,
+  createPatternOptionsWithContext,
+} from '../common/hooks.js';
 import { enLocale as message } from '@gsa-tts/forms-common';
 import styles from '../../formEditStyles.module.css';
 
@@ -41,7 +44,8 @@ const SelectDropdownPatternEdit: PatternEditComponent<SelectDropdownProps> = ({
 const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
   const { fieldId, getFieldState, register } =
     usePatternEditFormContext<SelectDropdownPattern>(pattern.id);
-  const { options, setOptions, deleteOption, updateOptionLabel } = createPatternOptionsWithContext(pattern);
+  const { options, setOptions, deleteOption, updateOptionLabel } =
+    createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
 

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -12,13 +12,13 @@ export type Option = {
   id: string;
   label: string;
   [key: string]: unknown;
-}
+};
 
 type UsePatternOptionsProps = {
   initialOptions: Option[];
   onOptionsChange?: (options: Option[]) => void;
   setValue?: (name: string, value: unknown) => void;
-}
+};
 
 type NestedKeys<T extends object> = {
   [K in keyof T & (string | number)]: T[K] extends object
@@ -46,8 +46,8 @@ export const usePatternEditFormContext = <T extends Pattern>(
 export const usePatternOptions = ({
   initialOptions,
   onOptionsChange,
-  setValue
-} : UsePatternOptionsProps) => {
+  setValue,
+}: UsePatternOptionsProps) => {
   const [options, setOptions] = useState<Option[]>(initialOptions);
 
   useEffect(() => {
@@ -56,8 +56,8 @@ export const usePatternOptions = ({
   }, [options, setValue, onOptionsChange]);
 
   const deleteOption = (optionId: string) => {
-    setOptions(options.filter(option => option.id !== optionId))
-  }
+    setOptions(options.filter(option => option.id !== optionId));
+  };
 
   const updateOptionLabel = (index: number, value: string) => {
     const newOptions = [...options];
@@ -71,7 +71,7 @@ export const usePatternOptions = ({
     options,
     setOptions,
     deleteOption,
-    updateOptionLabel
+    updateOptionLabel,
   };
 };
 
@@ -79,12 +79,14 @@ export const createPatternOptionsWithContext = <T extends Pattern>(
   pattern: T,
   patternEditContext?: ReturnType<typeof usePatternEditFormContext<T>>
 ) => {
-  const context = patternEditContext || usePatternEditFormContext<T>(pattern.id);
+  const context =
+    patternEditContext || usePatternEditFormContext<T>(pattern.id);
 
   return usePatternOptions({
     initialOptions: pattern.data.options || [],
-    setValue: (name, value) => context.setValue(name as NestedKeys<T['data']>, value)
+    setValue: (name, value) =>
+      context.setValue(name as NestedKeys<T['data']>, value),
   });
-}
+};
 
 export default usePatternOptions;

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -11,7 +11,7 @@ import {
 export type Option = {
   id: string;
   label: string;
-  [key: string]: string | number | readonly string[] | undefined | boolean;
+  [key: string]: string | number | readonly string[] | undefined;
 };
 
 type UsePatternOptionsProps = {

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 import {
@@ -6,6 +7,18 @@ import {
   type PatternMap,
   type PatternValue,
 } from '@gsa-tts/forms-core';
+
+export type Option = {
+  id: string;
+  label: string;
+  [key: string]: unknown;
+}
+
+type UsePatternOptionsProps = {
+  initialOptions: Option[];
+  onOptionsChange?: (options: Option[]) => void;
+  setValue?: (name: string, value: unknown) => void;
+}
 
 type NestedKeys<T extends object> = {
   [K in keyof T & (string | number)]: T[K] extends object
@@ -29,3 +42,49 @@ export const usePatternEditFormContext = <T extends Pattern>(
       setValue(`${patternId}.${path}`, value),
   };
 };
+
+export const usePatternOptions = ({
+  initialOptions,
+  onOptionsChange,
+  setValue
+} : UsePatternOptionsProps) => {
+  const [options, setOptions] = useState<Option[]>(initialOptions);
+
+  useEffect(() => {
+    setValue?.('options', options);
+    onOptionsChange?.(options);
+  }, [options, setValue, onOptionsChange]);
+
+  const deleteOption = (optionId: string) => {
+    setOptions(options.filter(option => option.id !== optionId))
+  }
+
+  const updateOptionLabel = (index: number, value: string) => {
+    const newOptions = [...options];
+    if (newOptions[index]) {
+      newOptions[index].label = value;
+      setOptions(newOptions);
+    }
+  };
+
+  return {
+    options,
+    setOptions,
+    deleteOption,
+    updateOptionLabel
+  };
+};
+
+export const createPatternOptionsWithContext = <T extends Pattern>(
+  pattern: T,
+  patternEditContext?: ReturnType<typeof usePatternEditFormContext<T>>
+) => {
+  const context = patternEditContext || usePatternEditFormContext<T>(pattern.id);
+
+  return usePatternOptions({
+    initialOptions: pattern.data.options || [],
+    setValue: (name, value) => context.setValue(name as NestedKeys<T['data']>, value)
+  });
+}
+
+export default usePatternOptions;

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -11,7 +11,7 @@ import {
 export type Option = {
   id: string;
   label: string;
-  [key: string]: string | number | readonly string[] | undefined;
+  [key: string]: string;
 };
 
 type UsePatternOptionsProps = {

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -17,7 +17,7 @@ export type Option = {
 type UsePatternOptionsProps = {
   initialOptions: Option[];
   onOptionsChange?: (options: Option[]) => void;
-  setValue?: (name: string, value: unknown) => void;
+  setValue?: (name: string, value: PatternValue) => void;
 };
 
 type NestedKeys<T extends object> = {

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -11,7 +11,7 @@ import {
 export type Option = {
   id: string;
   label: string;
-  [key: string]: unknown;
+  [key: string]: string | number | readonly string[] | undefined | boolean;
 };
 
 type UsePatternOptionsProps = {


### PR DESCRIPTION
*Overview*

This PR adds custom hook logic for deleting a choice option and updating an option label. This work also addresses the conversation @ethangardner and I discussed in this [PR](https://github.com/GSA-TTS/forms/pull/586#pullrequestreview-2741097986) comment thread. 

TCKT reference : [593](https://github.com/orgs/GSA-TTS/projects/17/views/8?pane=issue&itemId=105109270&issue=GSA-TTS%7Cforms%7C593)