### PR TITLE
Refactor: test form create page pattern

### DIFF
--- a/packages/design/src/Form/components/PageSet/PageSet.stories.tsx
+++ b/packages/design/src/Form/components/PageSet/PageSet.stories.tsx
@@ -21,12 +21,7 @@ const meta: Meta<typeof PageSet> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createPatternTestForm({ 
-            useSequence: true,
-            patternCount: 2,
-            requiredInputs: true,
-          })
-        })}
+          session={createTestSession({ form: createPatternTestForm() })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/Form/components/PageSet/PageSet.stories.tsx
+++ b/packages/design/src/Form/components/PageSet/PageSet.stories.tsx
@@ -8,7 +8,7 @@ import { FormManagerProvider } from '../../../FormManager/store.js';
 import {
   createTestFormManagerContext,
   createTestSession,
-  createTwoPatternTestForm,
+  createPatternTestForm,
 } from '../../../test-form.js';
 
 import PageSet from './PageSet.js';
@@ -21,7 +21,12 @@ const meta: Meta<typeof PageSet> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createTwoPatternTestForm() })}
+          session={createTestSession({ form: createPatternTestForm({ 
+            useSequence: true,
+            patternCount: 2,
+            requiredInputs: true,
+          })
+        })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
+++ b/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
@@ -20,11 +20,7 @@ const meta: Meta<typeof FormDelete> = {
   args: {
     formId: 'test-form',
     formService: createTestBrowserFormService({
-      'test-form': createPatternTestForm({
-        useSequence: true,
-        patternCount: 2,
-        requiredInputs: true,
-      }),
+      'test-form': createPatternTestForm(),
     }),
   },
   tags: ['autodocs'],

--- a/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
+++ b/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { createTestBrowserFormService } from '@gsa-tts/forms-core/context';
 
-import { createTwoPatternTestForm } from '../../test-form.js';
+import { createPatternTestForm } from '../../test-form.js';
 import FormDelete from './index.js';
 
 const meta: Meta<typeof FormDelete> = {
@@ -20,7 +20,11 @@ const meta: Meta<typeof FormDelete> = {
   args: {
     formId: 'test-form',
     formService: createTestBrowserFormService({
-      'test-form': createTwoPatternTestForm(),
+      'test-form': createPatternTestForm({
+        useSequence: true,
+        patternCount: 2,
+        requiredInputs: true,
+      }),
     }),
   },
   tags: ['autodocs'],

--- a/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
+++ b/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
@@ -17,11 +17,7 @@ const meta: Meta<typeof DocumentImporter> = {
   ],
   parameters: {
     formId: 'test-id',
-    form: createPatternTestForm({
-      useSequence: true,
-      patternCount: 2,
-      requiredInputs: true,
-    }),
+    form: createPatternTestForm(),
   },
   tags: ['autodocs'],
 };

--- a/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
+++ b/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import DocumentImporter from './index.js';
-import { createTwoPatternTestForm } from '../../../test-form.js';
+import { createPatternTestForm } from '../../../test-form.js';
 
 const meta: Meta<typeof DocumentImporter> = {
   title: 'FormManager/DocumentImporter',
@@ -17,7 +17,11 @@ const meta: Meta<typeof DocumentImporter> = {
   ],
   parameters: {
     formId: 'test-id',
-    form: createTwoPatternTestForm(),
+    form: createPatternTestForm({
+      useSequence: true,
+      patternCount: 2,
+      requiredInputs: true,
+    }),
   },
   tags: ['autodocs'],
 };

--- a/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<typeof FormEdit> = {
             form: createPatternTestForm({
               patternCount: 3,
               requiredInputs: false,
+              useSequence: false,
             }),
             route: {
               params: {

--- a/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
@@ -8,7 +8,7 @@ import { FormManagerProvider } from '../store.js';
 import FormEdit from './index.js';
 import {
   createTestSession,
-  createOnePageThreePatternTestForm,
+  createPatternTestForm,
   createTestFormManagerContext,
 } from '../../test-form.js';
 
@@ -21,7 +21,10 @@ const meta: Meta<typeof FormEdit> = {
         <FormManagerProvider
           context={createTestFormManagerContext()}
           session={createTestSession({
-            form: createOnePageThreePatternTestForm(),
+            form: createPatternTestForm({
+              patternCount: 3,
+              requiredInputs: false,
+            }),
             route: {
               params: {
                 page: '0',

--- a/packages/design/src/FormManager/FormEdit/components/DraggableList.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/DraggableList.stories.tsx
@@ -25,12 +25,7 @@ const meta: Meta<typeof DraggableList> = {
         <MemoryRouter initialEntries={['/']}>
           <FormManagerProvider
             context={createTestFormManagerContext()}
-            session={createTestSession({ form: createPatternTestForm({
-              useSequence: true,
-              patternCount: 2,
-              requiredInputs: true, 
-            })
-          })}
+            session={createTestSession({ form: createPatternTestForm() })}
           >
             <Story {...args} />
           </FormManagerProvider>

--- a/packages/design/src/FormManager/FormEdit/components/DraggableList.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/DraggableList.stories.tsx
@@ -6,7 +6,7 @@ import { FormManagerProvider, useFormManagerStore } from '../../store.js';
 import {
   createTestFormManagerContext,
   createTestSession,
-  createTwoPatternTestForm,
+  createPatternTestForm,
 } from '../../../test-form.js';
 
 import {
@@ -25,7 +25,12 @@ const meta: Meta<typeof DraggableList> = {
         <MemoryRouter initialEntries={['/']}>
           <FormManagerProvider
             context={createTestFormManagerContext()}
-            session={createTestSession({ form: createTwoPatternTestForm() })}
+            session={createTestSession({ form: createPatternTestForm({
+              useSequence: true,
+              patternCount: 2,
+              requiredInputs: true, 
+            })
+          })}
           >
             <Story {...args} />
           </FormManagerProvider>

--- a/packages/design/src/FormManager/FormEdit/components/PageSetEdit/PageSetEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PageSetEdit/PageSetEdit.stories.tsx
@@ -11,11 +11,10 @@ import { createPatternTestForm } from '../../../../test-form.js';
 const blueprint = createPatternTestForm({
   pageCount: 2,
   pageTitles: ['First page', 'Second page'],
-  patternCount: 2,
-  requiredInputs: true,
   patternDistribution: {
     0: ['element-1', 'element-2'],
   },
+  useSequence: false,
 });
 
 const storyConfig: Meta<typeof PageSetEdit> = {

--- a/packages/design/src/FormManager/FormEdit/components/PageSetEdit/PageSetEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PageSetEdit/PageSetEdit.stories.tsx
@@ -6,9 +6,17 @@ import {
   testUpdateFormFieldOnSubmitByElement,
 } from '../common/story-helper.js';
 import PageSetEdit from './index.js';
-import { createTwoPageTwoPatternTestForm } from '../../../../test-form.js';
+import { createPatternTestForm } from '../../../../test-form.js';
 
-const blueprint = createTwoPageTwoPatternTestForm();
+const blueprint = createPatternTestForm({
+  pageCount: 2,
+  pageTitles: ['First page', 'Second page'],
+  patternCount: 2,
+  requiredInputs: true,
+  patternDistribution: {
+    0: ['element-1', 'element-2'],
+  },
+});
 
 const storyConfig: Meta<typeof PageSetEdit> = {
   title: 'Edit components/PageSetEdit',

--- a/packages/design/src/FormManager/FormEdit/components/common/story-helper.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/common/story-helper.tsx
@@ -4,7 +4,7 @@ import { type Decorator, type Meta } from '@storybook/react';
 import { type Blueprint, type Pattern } from '@gsa-tts/forms-core';
 
 import {
-  createSimpleTestBlueprint,
+  createPatternTestForm,
   createTestFormManagerContext,
   createTestSession,
 } from '../../../../test-form.js';
@@ -26,7 +26,7 @@ export const createPatternEditStoryMeta = ({
   blueprint,
   decorators,
 }: PatternEditStoryMetaOptions): Meta<typeof FormEdit> => {
-  const form = blueprint ?? createSimpleTestBlueprint(pattern as Pattern);
+  const form = blueprint ?? createPatternTestForm({singlePattern: pattern as Pattern});
   return {
     title: 'Untitled pattern edit story',
     component: FormEdit,

--- a/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
+++ b/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
@@ -18,12 +18,7 @@ const meta: Meta<typeof CreateNew> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createPatternTestForm({
-            useSequence: true,
-            patternCount: 2,
-            requiredInputs: true,
-          })
-        })}
+          session={createTestSession({ form: createPatternTestForm() })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
+++ b/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import {
-  createTwoPatternTestForm,
+  createPatternTestForm,
   createTestSession,
   createTestFormManagerContext,
 } from '../../../test-form.js';
@@ -18,7 +18,12 @@ const meta: Meta<typeof CreateNew> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createTwoPatternTestForm() })}
+          session={createTestSession({ form: createPatternTestForm({
+            useSequence: true,
+            patternCount: 2,
+            requiredInputs: true,
+          })
+        })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/FormManager/FormList/FormList.stories.tsx
+++ b/packages/design/src/FormManager/FormList/FormList.stories.tsx
@@ -20,12 +20,7 @@ const meta: Meta<typeof FormList> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createPatternTestForm({
-            useSequence: true,
-            patternCount: 2,
-            requiredInputs: true,
-          })
-        })}
+          session={createTestSession({ form: createPatternTestForm() })}
         >
           <Story {...args} />
         </FormManagerProvider>
@@ -34,11 +29,7 @@ const meta: Meta<typeof FormList> = {
   ],
   args: {
     formService: createTestBrowserFormService({
-      'test-form': createPatternTestForm({
-        useSequence: true,
-        patternCount: 2,
-        requiredInputs: true,
-      }),
+      'test-form': createPatternTestForm(),
     }),
   },
   tags: ['autodocs'],

--- a/packages/design/src/FormManager/FormList/FormList.stories.tsx
+++ b/packages/design/src/FormManager/FormList/FormList.stories.tsx
@@ -6,7 +6,7 @@ import { createTestBrowserFormService } from '@gsa-tts/forms-core/context';
 
 import FormList from './index.js';
 import {
-  createTwoPatternTestForm,
+  createPatternTestForm,
   createTestSession,
   createTestFormManagerContext,
 } from '../../test-form.js';
@@ -20,7 +20,12 @@ const meta: Meta<typeof FormList> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createTwoPatternTestForm() })}
+          session={createTestSession({ form: createPatternTestForm({
+            useSequence: true,
+            patternCount: 2,
+            requiredInputs: true,
+          })
+        })}
         >
           <Story {...args} />
         </FormManagerProvider>
@@ -29,7 +34,11 @@ const meta: Meta<typeof FormList> = {
   ],
   args: {
     formService: createTestBrowserFormService({
-      'test-form': createTwoPatternTestForm(),
+      'test-form': createPatternTestForm({
+        useSequence: true,
+        patternCount: 2,
+        requiredInputs: true,
+      }),
     }),
   },
   tags: ['autodocs'],

--- a/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
+++ b/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
@@ -19,12 +19,7 @@ const meta: Meta<typeof FormManagerLayout> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createPatternTestForm({
-            useSequence: true,
-            patternCount: 2,
-            requiredInputs: true,
-          })
-        })}
+          session={createTestSession({ form: createPatternTestForm() })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
+++ b/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { FormManagerLayout } from './index.js';
 import {
-  createTwoPatternTestForm,
+  createPatternTestForm,
   createTestSession,
   createTestFormManagerContext,
 } from '../../test-form.js';
@@ -19,7 +19,12 @@ const meta: Meta<typeof FormManagerLayout> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createTwoPatternTestForm() })}
+          session={createTestSession({ form: createPatternTestForm({
+            useSequence: true,
+            patternCount: 2,
+            requiredInputs: true,
+          })
+        })}
         >
           <Story {...args} />
         </FormManagerProvider>

--- a/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
+++ b/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
@@ -19,12 +19,7 @@ const meta: Meta<typeof FormPreview> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createPatternTestForm({
-            useSequence: true,
-            patternCount: 2,
-            requiredInputs: true,
-          })
-        })}
+          session={createTestSession({ form: createPatternTestForm() })}
         >
           <Story {...args} />
         </FormManagerProvider>
@@ -33,11 +28,7 @@ const meta: Meta<typeof FormPreview> = {
   ],
   args: {
     context: createTestFormContext(),
-    form: createPatternTestForm({
-      useSequence: true,
-      patternCount: 2,
-      requiredInputs: true,
-    }),
+    form: createPatternTestForm(),
   },
   tags: ['autodocs'],
 };

--- a/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
+++ b/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { FormPreview } from './index.js';
 import {
-  createTwoPatternTestForm,
+  createPatternTestForm,
   createTestFormContext,
   createTestSession,
   createTestFormManagerContext,
@@ -19,7 +19,12 @@ const meta: Meta<typeof FormPreview> = {
       <MemoryRouter initialEntries={['/']}>
         <FormManagerProvider
           context={createTestFormManagerContext()}
-          session={createTestSession({ form: createTwoPatternTestForm() })}
+          session={createTestSession({ form: createPatternTestForm({
+            useSequence: true,
+            patternCount: 2,
+            requiredInputs: true,
+          })
+        })}
         >
           <Story {...args} />
         </FormManagerProvider>
@@ -28,7 +33,11 @@ const meta: Meta<typeof FormPreview> = {
   ],
   args: {
     context: createTestFormContext(),
-    form: createTwoPatternTestForm(),
+    form: createPatternTestForm({
+      useSequence: true,
+      patternCount: 2,
+      requiredInputs: true,
+    }),
   },
   tags: ['autodocs'],
 };

--- a/packages/design/src/FormManager/Notifications/Notifications.stories.tsx
+++ b/packages/design/src/FormManager/Notifications/Notifications.stories.tsx
@@ -30,12 +30,7 @@ export default {
     () => (
       <FormManagerProvider
         context={createTestFormManagerContext()}
-        session={createTestSession({ form: createPatternTestForm({
-          useSequence: true,
-          patternCount: 2,
-          requiredInputs: true,
-        })
-      })}
+        session={createTestSession({ form: createPatternTestForm() })}
       >
         <StoryImpl />
       </FormManagerProvider>

--- a/packages/design/src/FormManager/Notifications/Notifications.stories.tsx
+++ b/packages/design/src/FormManager/Notifications/Notifications.stories.tsx
@@ -6,7 +6,7 @@ import { FormManagerProvider, useFormManagerStore } from '../store.js';
 import {
   createTestFormManagerContext,
   createTestSession,
-  createTwoPatternTestForm,
+  createPatternTestForm,
 } from '../../test-form.js';
 
 const StoryImpl = () => {
@@ -30,7 +30,12 @@ export default {
     () => (
       <FormManagerProvider
         context={createTestFormManagerContext()}
-        session={createTestSession({ form: createTwoPatternTestForm() })}
+        session={createTestSession({ form: createPatternTestForm({
+          useSequence: true,
+          patternCount: 2,
+          requiredInputs: true,
+        })
+      })}
       >
         <StoryImpl />
       </FormManagerProvider>

--- a/packages/design/src/test-form.ts
+++ b/packages/design/src/test-form.ts
@@ -41,8 +41,8 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
       .fill(0)
       .map((_, i) => `Page ${i + 1}`),
     patternCount = 2,
-    requiredInputs = false,
-    useSequence = false,
+    requiredInputs = true,
+    useSequence = true,
     formTitle = 'Test form',
     formDescription = 'Test description',
     formSummaryTitle = 'New Form Title',
@@ -156,14 +156,6 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
   });
 };
 
-export const createTwoPatternTestForm = () => {
-  return createPatternTestForm({
-    useSequence: true,
-    patternCount: 2,
-    requiredInputs: true,
-  });
-};
-
 export const createTestFormConfig = () => {
   return defaultFormConfig;
 };
@@ -200,11 +192,7 @@ export const createTestSession = (options?: {
   route?: FormRoute;
 }) => {
   return createFormSession(
-    options?.form || createPatternTestForm({
-      useSequence: true,
-      patternCount: 2,
-      requiredInputs: true,
-    }),
+    options?.form || createPatternTestForm(),
     options?.route
   );
 };

--- a/packages/design/src/test-form.ts
+++ b/packages/design/src/test-form.ts
@@ -156,36 +156,11 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
   });
 };
 
-export const createOnePageThreePatternTestForm = () => {
-  return createPatternTestForm({
-    patternCount: 3,
-    requiredInputs: false,
-  });
-};
-
-export const createTwoPageTwoPatternTestForm = () => {
-  return createPatternTestForm({
-    pageCount: 2,
-    pageTitles: ['First page', 'Second page'],
-    patternCount: 2,
-    requiredInputs: true,
-    patternDistribution: {
-      0: ['element-1', 'element-2'],
-    },
-  });
-};
-
 export const createTwoPatternTestForm = () => {
   return createPatternTestForm({
     useSequence: true,
     patternCount: 2,
     requiredInputs: true,
-  });
-};
-
-export const createSimpleTestBlueprint = (pattern: Pattern) => {
-  return createPatternTestForm({
-    singlePattern: pattern,
   });
 };
 
@@ -225,7 +200,11 @@ export const createTestSession = (options?: {
   route?: FormRoute;
 }) => {
   return createFormSession(
-    options?.form || createTwoPatternTestForm(),
+    options?.form || createPatternTestForm({
+      useSequence: true,
+      patternCount: 2,
+      requiredInputs: true,
+    }),
     options?.route
   );
 };

--- a/packages/design/src/test-form.ts
+++ b/packages/design/src/test-form.ts
@@ -18,7 +18,6 @@ import { defaultPatternEditComponents } from './FormManager/FormEdit/components/
 import { type FormManagerContext } from './FormManager/index.js';
 import { FormRoute } from '../../forms/dist/types/route-data.js';
 
-
 export interface TestFormConfig {
   pageCount?: number;
   pageTitles?: string[];
@@ -31,14 +30,16 @@ export interface TestFormConfig {
   formSummaryDescription?: string;
   initialValues?: string[];
   patternLabels?: string[];
-  patternDistribution?: Record<number, string[]>
+  patternDistribution?: Record<number, string[]>;
   singlePattern?: Pattern;
 }
 
 export const createPatternTestForm = (config: TestFormConfig = {}) => {
   const {
     pageCount = 1,
-    pageTitles = Array(Math.max(1, pageCount)).fill(0).map((_, i) => `Page ${i + 1}`),
+    pageTitles = Array(Math.max(1, pageCount))
+      .fill(0)
+      .map((_, i) => `Page ${i + 1}`),
     patternCount = 2,
     requiredInputs = false,
     useSequence = false,
@@ -46,38 +47,45 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
     formDescription = 'Test description',
     formSummaryTitle = 'New Form Title',
     formSummaryDescription = 'New form description',
-    initialValues = ['', 'test', ...Array(Math.max(0, patternCount - 2)).fill('')],
-    patternLabels = Array(Math.max(1, patternCount)).fill(0).map((_, i) => `Pattern ${i + 1}`),
-    singlePattern = null
+    initialValues = [
+      '',
+      'test',
+      ...Array(Math.max(0, patternCount - 2)).fill(''),
+    ],
+    patternLabels = Array(Math.max(1, patternCount))
+      .fill(0)
+      .map((_, i) => `Pattern ${i + 1}`),
+    singlePattern = null,
   } = config;
-  
+
   const formMeta = {
     title: formTitle,
     description: formDescription,
   };
-  
-  const pageIds = Array(pageCount).fill(0).map((_, i) => `page-${i + 1}`);
-  const inputIds = Array(patternCount).fill(0).map((_, i) => `element-${i + 1}`);
+
+  const pageIds = Array(pageCount)
+    .fill(0)
+    .map((_, i) => `page-${i + 1}`);
+  const inputIds = Array(patternCount)
+    .fill(0)
+    .map((_, i) => `element-${i + 1}`);
   const formSummaryId = 'form-summary-1';
   const patterns: Pattern[] = [];
-  
+
   if (singlePattern) {
-    return createForm(
-      formMeta,
-      {
-        root: 'root',
-        patterns: [
-          {
-            type: 'sequence',
-            id: 'root',
-            data: {
-              patterns: [singlePattern.id],
-            },
-          } as SequencePattern,
-          singlePattern,
-        ],
-      }
-    );
+    return createForm(formMeta, {
+      root: 'root',
+      patterns: [
+        {
+          type: 'sequence',
+          id: 'root',
+          data: {
+            patterns: [singlePattern.id],
+          },
+        } as SequencePattern,
+        singlePattern,
+      ],
+    });
   }
 
   if (useSequence) {
@@ -96,20 +104,20 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
         pages: pageIds,
       },
     } as PageSetPattern);
-    
+
     pageIds.forEach((pageId, index) => {
       let pagePatterns: string[] = [];
-      
+
       if (index === 0) {
         pagePatterns.push(formSummaryId);
       }
-      
+
       if (config.patternDistribution && config.patternDistribution[index]) {
         pagePatterns = [...pagePatterns, ...config.patternDistribution[index]];
       } else if (index === 0) {
         pagePatterns = [...pagePatterns, ...inputIds];
       }
-      
+
       patterns.push({
         type: 'page',
         id: pageId,
@@ -120,7 +128,7 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
       } as PagePattern);
     });
   }
-  
+
   inputIds.forEach((id, index) => {
     patterns.push({
       type: 'input',
@@ -132,7 +140,7 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
       },
     } as InputPattern);
   });
-  
+
   patterns.push({
     type: 'form-summary',
     id: formSummaryId,
@@ -141,20 +149,17 @@ export const createPatternTestForm = (config: TestFormConfig = {}) => {
       description: formSummaryDescription,
     },
   } as FormSummaryPattern);
-  
-  return createForm(
-    formMeta,
-    {
-      root: 'root',
-      patterns,
-    }
-  );
+
+  return createForm(formMeta, {
+    root: 'root',
+    patterns,
+  });
 };
 
 export const createOnePageThreePatternTestForm = () => {
   return createPatternTestForm({
     patternCount: 3,
-    requiredInputs: false
+    requiredInputs: false,
   });
 };
 
@@ -165,8 +170,8 @@ export const createTwoPageTwoPatternTestForm = () => {
     patternCount: 2,
     requiredInputs: true,
     patternDistribution: {
-      0: ['element-1', 'element-2']
-    }
+      0: ['element-1', 'element-2'],
+    },
   });
 };
 
@@ -174,13 +179,13 @@ export const createTwoPatternTestForm = () => {
   return createPatternTestForm({
     useSequence: true,
     patternCount: 2,
-    requiredInputs: true
+    requiredInputs: true,
   });
 };
 
 export const createSimpleTestBlueprint = (pattern: Pattern) => {
   return createPatternTestForm({
-    singlePattern: pattern
+    singlePattern: pattern,
   });
 };
 

--- a/packages/design/src/test-form.ts
+++ b/packages/design/src/test-form.ts
@@ -2,7 +2,6 @@ import {
   createForm,
   createFormSession,
   defaultFormConfig,
-  FormSummaryPattern,
   type Blueprint,
   type Pattern,
 } from '@gsa-tts/forms-core';
@@ -12,197 +11,177 @@ import { type PagePattern } from '@gsa-tts/forms-core';
 import { type PageSetPattern } from '@gsa-tts/forms-core';
 import { type SequencePattern } from '@gsa-tts/forms-core';
 
+import { type FormSummaryPattern } from '@gsa-tts/forms-core';
 import { type FormUIContext } from './Form/index.js';
 import { defaultPatternComponents } from './Form/components/index.js';
 import { defaultPatternEditComponents } from './FormManager/FormEdit/components/index.js';
 import { type FormManagerContext } from './FormManager/index.js';
 import { FormRoute } from '../../forms/dist/types/route-data.js';
 
-export const createOnePageThreePatternTestForm = () => {
-  return createForm(
-    {
-      title: 'Test form',
-      description: 'Test description',
+
+export interface TestFormConfig {
+  pageCount?: number;
+  pageTitles?: string[];
+  patternCount?: number;
+  requiredInputs?: boolean;
+  useSequence?: boolean;
+  formTitle?: string;
+  formDescription?: string;
+  formSummaryTitle?: string;
+  formSummaryDescription?: string;
+  initialValues?: string[];
+  patternLabels?: string[];
+  patternDistribution?: Record<number, string[]>
+  singlePattern?: Pattern;
+}
+
+export const createPatternTestForm = (config: TestFormConfig = {}) => {
+  const {
+    pageCount = 1,
+    pageTitles = Array(Math.max(1, pageCount)).fill(0).map((_, i) => `Page ${i + 1}`),
+    patternCount = 2,
+    requiredInputs = false,
+    useSequence = false,
+    formTitle = 'Test form',
+    formDescription = 'Test description',
+    formSummaryTitle = 'New Form Title',
+    formSummaryDescription = 'New form description',
+    initialValues = ['', 'test', ...Array(Math.max(0, patternCount - 2)).fill('')],
+    patternLabels = Array(Math.max(1, patternCount)).fill(0).map((_, i) => `Pattern ${i + 1}`),
+    singlePattern = null
+  } = config;
+  
+  const formMeta = {
+    title: formTitle,
+    description: formDescription,
+  };
+  
+  const pageIds = Array(pageCount).fill(0).map((_, i) => `page-${i + 1}`);
+  const inputIds = Array(patternCount).fill(0).map((_, i) => `element-${i + 1}`);
+  const formSummaryId = 'form-summary-1';
+  const patterns: Pattern[] = [];
+  
+  if (singlePattern) {
+    return createForm(
+      formMeta,
+      {
+        root: 'root',
+        patterns: [
+          {
+            type: 'sequence',
+            id: 'root',
+            data: {
+              patterns: [singlePattern.id],
+            },
+          } as SequencePattern,
+          singlePattern,
+        ],
+      }
+    );
+  }
+
+  if (useSequence) {
+    patterns.push({
+      type: 'sequence',
+      id: 'root',
+      data: {
+        patterns: [formSummaryId, ...inputIds],
+      },
+    } as SequencePattern);
+  } else {
+    patterns.push({
+      type: 'page-set',
+      id: 'root',
+      data: {
+        pages: pageIds,
+      },
+    } as PageSetPattern);
+    
+    pageIds.forEach((pageId, index) => {
+      let pagePatterns: string[] = [];
+      
+      if (index === 0) {
+        pagePatterns.push(formSummaryId);
+      }
+      
+      if (config.patternDistribution && config.patternDistribution[index]) {
+        pagePatterns = [...pagePatterns, ...config.patternDistribution[index]];
+      } else if (index === 0) {
+        pagePatterns = [...pagePatterns, ...inputIds];
+      }
+      
+      patterns.push({
+        type: 'page',
+        id: pageId,
+        data: {
+          title: pageTitles[index] || `Page ${index + 1}`,
+          patterns: pagePatterns,
+        },
+      } as PagePattern);
+    });
+  }
+  
+  inputIds.forEach((id, index) => {
+    patterns.push({
+      type: 'input',
+      id,
+      data: {
+        label: patternLabels[index] || `Pattern ${index + 1}`,
+        initial: initialValues[index] || '',
+        required: requiredInputs,
+      },
+    } as InputPattern);
+  });
+  
+  patterns.push({
+    type: 'form-summary',
+    id: formSummaryId,
+    data: {
+      title: formSummaryTitle,
+      description: formSummaryDescription,
     },
+  } as FormSummaryPattern);
+  
+  return createForm(
+    formMeta,
     {
       root: 'root',
-      patterns: [
-        {
-          type: 'page-set',
-          id: 'root',
-          data: {
-            pages: ['page-1'],
-          },
-        } satisfies PageSetPattern,
-        {
-          type: 'page',
-          id: 'page-1',
-          data: {
-            title: 'Page 1',
-            patterns: ['form-summary-1', 'element-1', 'element-2'],
-          },
-        } satisfies PagePattern,
-        {
-          type: 'input',
-          id: 'element-1',
-          data: {
-            label: 'Pattern 1',
-            initial: '',
-            required: false,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'input',
-          id: 'element-2',
-          data: {
-            label: 'Pattern 2',
-            initial: 'test',
-            required: false,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'form-summary',
-          id: 'form-summary-1',
-          data: {
-            title: 'New Form Title',
-            description: 'New form description',
-          },
-        } satisfies FormSummaryPattern,
-      ],
+      patterns,
     }
   );
+};
+
+export const createOnePageThreePatternTestForm = () => {
+  return createPatternTestForm({
+    patternCount: 3,
+    requiredInputs: false
+  });
 };
 
 export const createTwoPageTwoPatternTestForm = () => {
-  return createForm(
-    {
-      title: 'Test form',
-      description: 'Test description',
-    },
-    {
-      root: 'root',
-      patterns: [
-        {
-          type: 'page-set',
-          id: 'root',
-          data: {
-            pages: ['page-1', 'page-2'],
-          },
-        } satisfies PageSetPattern,
-        {
-          type: 'page',
-          id: 'page-1',
-          data: {
-            title: 'First page',
-            patterns: ['form-summary-1', 'element-1', 'element-2'],
-          },
-        } satisfies PagePattern,
-        {
-          type: 'page',
-          id: 'page-2',
-          data: {
-            title: 'Second page',
-            patterns: [],
-          },
-        } satisfies PagePattern,
-        {
-          type: 'input',
-          id: 'element-1',
-          data: {
-            label: 'Pattern 1',
-            initial: '',
-            required: true,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'input',
-          id: 'element-2',
-          data: {
-            label: 'Pattern 2',
-            initial: 'test',
-            required: true,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'form-summary',
-          id: 'form-summary-1',
-          data: {
-            title: 'New Form Title',
-            description: 'New form description',
-          },
-        } satisfies FormSummaryPattern,
-      ],
+  return createPatternTestForm({
+    pageCount: 2,
+    pageTitles: ['First page', 'Second page'],
+    patternCount: 2,
+    requiredInputs: true,
+    patternDistribution: {
+      0: ['element-1', 'element-2']
     }
-  );
+  });
 };
 
 export const createTwoPatternTestForm = () => {
-  return createForm(
-    {
-      title: 'Test form',
-      description: 'Test description',
-    },
-    {
-      root: 'root',
-      patterns: [
-        {
-          type: 'sequence',
-          id: 'root',
-          data: {
-            patterns: ['form-summary-1', 'element-1', 'element-2'],
-          },
-        } satisfies SequencePattern,
-        {
-          type: 'input',
-          id: 'element-1',
-          data: {
-            label: 'Pattern 1',
-            initial: '',
-            required: true,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'input',
-          id: 'element-2',
-          data: {
-            label: 'Pattern 2',
-            initial: 'test',
-            required: true,
-          },
-        } satisfies InputPattern,
-        {
-          type: 'form-summary',
-          id: 'form-summary-1',
-          data: {
-            title: 'New Form Title',
-            description: 'New form description',
-          },
-        } satisfies FormSummaryPattern,
-      ],
-    }
-  );
+  return createPatternTestForm({
+    useSequence: true,
+    patternCount: 2,
+    requiredInputs: true
+  });
 };
 
 export const createSimpleTestBlueprint = (pattern: Pattern) => {
-  return createForm(
-    {
-      title: 'Test form',
-      description: 'Test description',
-    },
-    {
-      root: 'root',
-      patterns: [
-        {
-          type: 'sequence',
-          id: 'root',
-          data: {
-            patterns: [pattern.id],
-          },
-        } satisfies SequencePattern,
-        pattern,
-      ],
-    }
-  );
+  return createPatternTestForm({
+    singlePattern: pattern
+  });
 };
 
 export const createTestFormConfig = () => {


### PR DESCRIPTION
*Overview*

This PR attempts to refactor the methods used to create form test patterns and pages and addresses this [comment](https://github.com/GSA-TTS/forms/pull/600#discussion_r2039660967).


This refactor itself could be refactored to be a bit more SOLID. However, I didn't want to invest _too_ much time into this. While this PR an improvement and makes the creation process a bit more flexible, we do lose readability.

References [TCKT](https://github.com/orgs/GSA-TTS/projects/17/views/8?pane=issue&itemId=106095672&issue=GSA-TTS%7Cforms%7C603)