### PR TITLE
feat: adds ability to reorder choice option components on Choice edit stage

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/CheckboxGroupPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/CheckboxGroupPatternEdit.stories.tsx
@@ -78,6 +78,33 @@ export const AddField: StoryObj<typeof FormEdit> = {
   },
 };
 
+export const DeleteField: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByText(message.patterns.checkboxGroup.displayName)
+    );
+
+    await expect(canvas.getByLabelText('Option 2 label')).toBeInTheDocument();
+
+    const option2Element = canvas.getByLabelText('Option 2 label');
+    const option2Row = option2Element.closest('div');
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
+    
+    const originalConfirm = window.confirm;
+    window.confirm = () => true;
+    
+    await userEvent.click(deleteButton);
+  
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    window.confirm = originalConfirm;
+
+    await expect(canvas.getByLabelText('Option 1 label')).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue('Option 3')).toBeInTheDocument();
+  },
+};
+
 export const Error: StoryObj<typeof CheckboxGroupPatternEdit> = {
   play: async ({ canvasElement }) => {
     userEvent.setup();

--- a/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/CheckboxGroupPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/CheckboxGroupPatternEdit.stories.tsx
@@ -90,13 +90,15 @@ export const DeleteField: StoryObj<typeof FormEdit> = {
 
     const option2Element = canvas.getByLabelText('Option 2 label');
     const option2Row = option2Element.closest('div');
-    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
-    
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', {
+      name: /delete/i,
+    });
+
     const originalConfirm = window.confirm;
     window.confirm = () => true;
-    
+
     await userEvent.click(deleteButton);
-  
+
     await new Promise(resolve => setTimeout(resolve, 3000));
     window.confirm = originalConfirm;
 

--- a/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/index.tsx
@@ -1,6 +1,9 @@
 import classnames from 'classnames';
 import React from 'react';
 
+import { UniqueIdentifier } from '@dnd-kit/core';
+import { DraggableList } from '../PreviewSequencePattern/DraggableList.js';
+
 import { type CheckboxGroupProps } from '@gsa-tts/forms-core';
 import { type CheckboxGroupPattern } from '@gsa-tts/forms-core';
 
@@ -47,6 +50,15 @@ const EditComponent = ({ pattern }: { pattern: CheckboxGroupPattern }) => {
     createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
+
+  const optionIds = options.map(option => option.id as UniqueIdentifier);
+
+  const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
+    const reorderedOptions = newOrder.map(id => 
+      options.find(option => option.id === id)!
+    );
+    setOptions(reorderedOptions);
+  };
 
   return (
     <div className="grid-row grid-gap">
@@ -106,51 +118,57 @@ const EditComponent = ({ pattern }: { pattern: CheckboxGroupPattern }) => {
         </label>
       </div>
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
-        {options.map((option, index) => {
-          const optionId = getFieldState(`options.${index}.id`);
-          const optionLabel = getFieldState(`options.${index}.label`);
-          return (
-            <div key={index}>
-              {optionId.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionId.error.message}
-                </span>
-              ) : null}
-              {optionLabel.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionLabel.error.message}
-                </span>
-              ) : null}
-              <div className="display-flex margin-bottom-2">
-                <input
-                  className={classnames('hide', 'usa-input', {
-                    'usa-label--error': label.error,
-                  })}
-                  id={fieldId(`options.${index}.id`)}
-                  {...register(`options.${index}.id`)}
-                  defaultValue={option.id}
-                  aria-label={`Option ${index + 1} id`}
-                />
-                <label
-                  htmlFor={`options-${index}.id`}
-                  className={`usa-checkbox__label ${styles.optionCircle}`}
-                ></label>
-                <input
-                  className="usa-input bg-primary-lighter"
-                  id={fieldId(`options.${index}.label`)}
-                  {...register(`options.${index}.label`)}
-                  value={option.label}
-                  onChange={e => updateOptionLabel(index, e.target.value)}
-                  aria-label={`Option ${index + 1} label`}
-                />
-                <PatternOptionActions
-                  optionId={option.id}
-                  onDelete={deleteOption}
-                />
+        <DraggableList
+          order={optionIds}
+          updateOrder={updateOptionOrder}
+          presentation="compact-center"
+        >
+          {options.map((option, index) => {
+            const optionId = getFieldState(`options.${index}.id`);
+            const optionLabel = getFieldState(`options.${index}.label`);
+            return (
+              <div key={index}>
+                {optionId.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionId.error.message}
+                  </span>
+                ) : null}
+                {optionLabel.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionLabel.error.message}
+                  </span>
+                ) : null}
+                <div className="display-flex margin-bottom-2">
+                  <input
+                    className={classnames('hide', 'usa-input', {
+                      'usa-label--error': label.error,
+                    })}
+                    id={fieldId(`options.${index}.id`)}
+                    {...register(`options.${index}.id`)}
+                    defaultValue={option.id}
+                    aria-label={`Option ${index + 1} id`}
+                  />
+                  <label
+                    htmlFor={`options-${index}.id`}
+                    className={`usa-checkbox__label ${styles.optionCircle}`}
+                  ></label>
+                  <input
+                    className="usa-input bg-primary-lighter"
+                    id={fieldId(`options.${index}.label`)}
+                    {...register(`options.${index}.label`)}
+                    value={option.label}
+                    onChange={e => updateOptionLabel(index, e.target.value)}
+                    aria-label={`Option ${index + 1} label`}
+                  />
+                  <PatternOptionActions
+                    optionId={option.id}
+                    onDelete={deleteOption}
+                  />
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </DraggableList>
         <button
           className={`usa-link ${styles.addMorePatternButton}`}
           type="button"

--- a/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/CheckboxGroupPatternEdit/index.tsx
@@ -54,8 +54,8 @@ const EditComponent = ({ pattern }: { pattern: CheckboxGroupPattern }) => {
   const optionIds = options.map(option => option.id as UniqueIdentifier);
 
   const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
-    const reorderedOptions = newOrder.map(id => 
-      options.find(option => option.id === id)!
+    const reorderedOptions = newOrder.map(
+      id => options.find(option => option.id === id)!
     );
     setOptions(reorderedOptions);
   };

--- a/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
@@ -22,7 +22,10 @@ import { useFormManagerStore } from '../../../store.js';
 import styles from '../../formEditStyles.module.css';
 import classNames from 'classnames';
 
-export type DraggableListPresentation = 'compact' | 'compact-center' | 'default';
+export type DraggableListPresentation =
+  | 'compact'
+  | 'compact-center'
+  | 'default';
 export type DraggableListProps = React.PropsWithChildren<{
   order: UniqueIdentifier[];
   updateOrder: (order: UniqueIdentifier[]) => void;
@@ -151,7 +154,8 @@ const SortableItemOverlay = ({
         </div>
         <div
           className={classNames('grid-col', {
-            'flex-fill': presentation === 'compact' || presentation == 'compact-center',
+            'flex-fill':
+              presentation === 'compact' || presentation == 'compact-center',
             'grid-col-12': presentation === 'default',
           })}
         >
@@ -188,7 +192,8 @@ const SortableItem = ({
         'cursor-pointer',
         {
           'margin-bottom-3': presentation === 'default',
-          'border-top-1px': presentation === 'compact' || presentation == 'compact-center',
+          'border-top-1px':
+            presentation === 'compact' || presentation == 'compact-center',
           'border-base-lighter': presentation === 'compact',
         }
       )}
@@ -205,7 +210,8 @@ const SortableItem = ({
     >
       <div
         className={classNames('grid-row', {
-          'display-flex': presentation === 'compact' || presentation == 'compact-center',
+          'display-flex':
+            presentation === 'compact' || presentation == 'compact-center',
         })}
       >
         <div
@@ -234,7 +240,8 @@ const SortableItem = ({
         </div>
         <div
           className={classNames('grid-col', {
-            'flex-fill': presentation === 'compact' || presentation == 'compact-center',
+            'flex-fill':
+              presentation === 'compact' || presentation == 'compact-center',
             'grid-col-12': presentation === 'default',
           })}
         >

--- a/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
@@ -22,7 +22,7 @@ import { useFormManagerStore } from '../../../store.js';
 import styles from '../../formEditStyles.module.css';
 import classNames from 'classnames';
 
-export type DraggableListPresentation = 'compact' | 'default';
+export type DraggableListPresentation = 'compact' | 'compact-center' | 'default';
 export type DraggableListProps = React.PropsWithChildren<{
   order: UniqueIdentifier[];
   updateOrder: (order: UniqueIdentifier[]) => void;
@@ -131,6 +131,7 @@ const SortableItemOverlay = ({
         <div
           className={classNames('draggable-list-button', {
             'width-5 padding-1': presentation === 'compact',
+            'width-5 padding-1 margin-y-2': presentation == 'compact-center',
             'grid-col-12 width-full padding-2': presentation === 'default',
           })}
           style={{
@@ -150,7 +151,7 @@ const SortableItemOverlay = ({
         </div>
         <div
           className={classNames('grid-col', {
-            'flex-fill': presentation === 'compact',
+            'flex-fill': presentation === 'compact' || presentation == 'compact-center',
             'grid-col-12': presentation === 'default',
           })}
         >
@@ -187,7 +188,7 @@ const SortableItem = ({
         'cursor-pointer',
         {
           'margin-bottom-3': presentation === 'default',
-          'border-top-1px': presentation === 'compact',
+          'border-top-1px': presentation === 'compact' || presentation == 'compact-center',
           'border-base-lighter': presentation === 'compact',
         }
       )}
@@ -204,12 +205,13 @@ const SortableItem = ({
     >
       <div
         className={classNames('grid-row', {
-          'display-flex': presentation === 'compact',
+          'display-flex': presentation === 'compact' || presentation == 'compact-center',
         })}
       >
         <div
           className={classNames({
             'width-5 padding-1': presentation === 'compact',
+            'width-5 padding-1 margin-y-2': presentation == 'compact-center',
             'grid-col-12 width-full padding-2': presentation === 'default',
           })}
           {...listeners}
@@ -232,7 +234,7 @@ const SortableItem = ({
         </div>
         <div
           className={classNames('grid-col', {
-            'flex-fill': presentation === 'compact',
+            'flex-fill': presentation === 'compact' || presentation == 'compact-center',
             'grid-col-12': presentation === 'default',
           })}
         >

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
@@ -94,13 +94,15 @@ export const DeleteField: StoryObj<typeof FormEdit> = {
 
     const option2Element = canvas.getByLabelText('Option 2 label');
     const option2Row = option2Element.closest('div');
-    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
-    
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', {
+      name: /delete/i,
+    });
+
     const originalConfirm = window.confirm;
     window.confirm = () => true;
-    
+
     await userEvent.click(deleteButton);
-  
+
     await new Promise(resolve => setTimeout(resolve, 3000));
     window.confirm = originalConfirm;
 

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/RadioGroupPatternEdit.stories.tsx
@@ -82,6 +82,33 @@ export const AddField: StoryObj<typeof FormEdit> = {
   },
 };
 
+export const DeleteField: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByText(message.patterns.radioGroup.displayName)
+    );
+
+    await expect(canvas.getByLabelText('Option 2 label')).toBeInTheDocument();
+
+    const option2Element = canvas.getByLabelText('Option 2 label');
+    const option2Row = option2Element.closest('div');
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
+    
+    const originalConfirm = window.confirm;
+    window.confirm = () => true;
+    
+    await userEvent.click(deleteButton);
+  
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    window.confirm = originalConfirm;
+
+    await expect(canvas.getByLabelText('Option 1 label')).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue('Option 3')).toBeInTheDocument();
+  },
+};
+
 export const Error: StoryObj<typeof CheckboxPatternEdit> = {
   play: async ({ canvasElement }) => {
     userEvent.setup();

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -1,6 +1,8 @@
 import classnames from 'classnames';
 import React from 'react';
 
+import { UniqueIdentifier } from '@dnd-kit/core';
+import { DraggableList } from '../PreviewSequencePattern/DraggableList.js';
 import { type RadioGroupProps } from '@gsa-tts/forms-core';
 import { type RadioGroupPattern } from '@gsa-tts/forms-core';
 
@@ -47,6 +49,15 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
     createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
+
+  const optionIds = options.map(option => option.id as UniqueIdentifier);
+
+  const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
+    const reorderedOptions = newOrder.map(id => 
+      options.find(option => option.id === id)!
+    );
+    setOptions(reorderedOptions);
+  };
 
   return (
     <div className="grid-row grid-gap">
@@ -106,51 +117,57 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
         </label>
       </div>
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
-        {options.map((option, index) => {
-          const optionId = getFieldState(`options.${index}.id`);
-          const optionLabel = getFieldState(`options.${index}.label`);
-          return (
-            <div key={index}>
-              {optionId.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionId.error.message}
-                </span>
-              ) : null}
-              {optionLabel.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionLabel.error.message}
-                </span>
-              ) : null}
-              <div className="display-flex margin-bottom-2">
-                <input
-                  className={classnames('hide', 'usa-input', {
-                    'usa-label--error': label.error,
-                  })}
-                  id={fieldId(`options.${index}.id`)}
-                  {...register(`options.${index}.id`)}
-                  defaultValue={option.id}
-                  aria-label={`Option ${index + 1} id`}
-                />
-                <label
-                  htmlFor={`options-${index}.id`}
-                  className={`usa-radio__label ${styles.optionCircle}`}
-                ></label>
-                <input
-                  className="usa-input bg-primary-lighter"
-                  id={fieldId(`options.${index}.label`)}
-                  {...register(`options.${index}.label`)}
-                  value={option.label}
-                  onChange={e => updateOptionLabel(index, e.target.value)}
-                  aria-label={`Option ${index + 1} label`}
-                />
-                <PatternOptionActions
-                  optionId={option.id}
-                  onDelete={deleteOption}
-                />
+        <DraggableList
+          order={optionIds}
+          updateOrder={updateOptionOrder}
+          presentation="compact-center"
+        >
+          {options.map((option, index) => {
+            const optionId = getFieldState(`options.${index}.id`);
+            const optionLabel = getFieldState(`options.${index}.label`);
+            return (
+              <div key={index}>
+                {optionId.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionId.error.message}
+                  </span>
+                ) : null}
+                {optionLabel.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionLabel.error.message}
+                  </span>
+                ) : null}
+                <div className="display-flex margin-bottom-2">
+                  <input
+                    className={classnames('hide', 'usa-input', {
+                      'usa-label--error': label.error,
+                    })}
+                    id={fieldId(`options.${index}.id`)}
+                    {...register(`options.${index}.id`)}
+                    defaultValue={option.id}
+                    aria-label={`Option ${index + 1} id`}
+                  />
+                  <label
+                    htmlFor={`options-${index}.id`}
+                    className={`usa-radio__label ${styles.optionCircle}`}
+                  ></label>
+                  <input
+                    className="usa-input bg-primary-lighter"
+                    id={fieldId(`options.${index}.label`)}
+                    {...register(`options.${index}.label`)}
+                    value={option.label}
+                    onChange={e => updateOptionLabel(index, e.target.value)}
+                    aria-label={`Option ${index + 1} label`}
+                  />
+                  <PatternOptionActions
+                    optionId={option.id}
+                    onDelete={deleteOption}
+                  />
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </DraggableList>
         <button
           className={`usa-link ${styles.addMorePatternButton}`}
           type="button"

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit/index.tsx
@@ -53,8 +53,8 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
   const optionIds = options.map(option => option.id as UniqueIdentifier);
 
   const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
-    const reorderedOptions = newOrder.map(id => 
-      options.find(option => option.id === id)!
+    const reorderedOptions = newOrder.map(
+      id => options.find(option => option.id === id)!
     );
     setOptions(reorderedOptions);
   };

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
@@ -82,6 +82,33 @@ export const AddField: StoryObj<typeof FormEdit> = {
   },
 };
 
+export const DeleteField: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByText(message.patterns.selectDropdown.displayName)
+    );
+
+    await expect(canvas.getByLabelText('Option 2 label')).toBeInTheDocument();
+
+    const option2Element = canvas.getByLabelText('Option 2 label');
+    const option2Row = option2Element.closest('div');
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
+    
+    const originalConfirm = window.confirm;
+    window.confirm = () => true;
+    
+    await userEvent.click(deleteButton);
+  
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    window.confirm = originalConfirm;
+
+    await expect(canvas.getByDisplayValue('Option-1')).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue('Option-3')).toBeInTheDocument();
+  },
+};
+
 export const Error: StoryObj<typeof FormEdit> = {
   play: async ({ canvasElement }) => {
     userEvent.setup();

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/SelectDropdownPatternEdit.stories.tsx
@@ -94,17 +94,19 @@ export const DeleteField: StoryObj<typeof FormEdit> = {
 
     const option2Element = canvas.getByLabelText('Option 2 label');
     const option2Row = option2Element.closest('div');
-    const deleteButton = within(option2Row as HTMLElement).getByRole('button', { name: /delete/i });
-    
+    const deleteButton = within(option2Row as HTMLElement).getByRole('button', {
+      name: /delete/i,
+    });
+
     const originalConfirm = window.confirm;
     window.confirm = () => true;
-    
+
     await userEvent.click(deleteButton);
-  
+
     await new Promise(resolve => setTimeout(resolve, 3000));
     window.confirm = originalConfirm;
 
-    await expect(canvas.getByDisplayValue('Option-1')).toBeInTheDocument();
+    await expect(canvas.getByLabelText('Option 1 label')).toBeInTheDocument();
     await expect(canvas.getByDisplayValue('Option-3')).toBeInTheDocument();
   },
 };

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -1,6 +1,9 @@
 import classnames from 'classnames';
 import React from 'react';
 
+import { UniqueIdentifier } from '@dnd-kit/core';
+import { DraggableList } from '../PreviewSequencePattern/DraggableList.js';
+
 import { type SelectDropdownProps } from '@gsa-tts/forms-core';
 import { type SelectDropdownPattern } from '@gsa-tts/forms-core';
 
@@ -48,6 +51,15 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
     createPatternOptionsWithContext(pattern);
   const label = getFieldState('label');
   const hint = getFieldState('hint');
+
+  const optionIds = options.map(option => option.id as UniqueIdentifier);
+
+  const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
+    const reorderedOptions = newOrder.map(id => 
+      options.find(option => option.id === id)!
+    );
+    setOptions(reorderedOptions);
+  };
 
   return (
     <div className="grid-row grid-gap">
@@ -105,51 +117,57 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
         </label>
       </div>
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
-        {options.map((option, index) => {
-          const optionValue = getFieldState(`options.${index}.value`);
-          const optionLabel = getFieldState(`options.${index}.label`);
-          return (
-            <div key={index}>
-              {optionValue.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionValue.error.message}
-                </span>
-              ) : null}
-              {optionLabel.error ? (
-                <span className="usa-error-message" role="alert">
-                  {optionLabel.error.message}
-                </span>
-              ) : null}
-              <div className="display-flex margin-bottom-2">
-                <input
-                  className={classnames('hide', 'usa-input', {
-                    'usa-label--error': label.error,
-                  })}
-                  id={fieldId(`options.${index}.value`)}
-                  {...register(`options.${index}.value`)}
-                  defaultValue={option.value}
-                  aria-label={`Option ${index + 1} value`}
-                />
-                <label
-                  htmlFor={`options-${index}.id`}
-                  className={`usa-radio__label ${styles.optionCircle}`}
-                ></label>
-                <input
-                  className="usa-input bg-primary-lighter"
-                  id={fieldId(`options.${index}.label`)}
-                  {...register(`options.${index}.label`)}
-                  value={option.label}
-                  onChange={e => updateOptionLabel(index, e.target.value)}
-                  aria-label={`Option ${index + 1} label`}
-                />
-                <PatternOptionActions
-                  optionId={option.id}
-                  onDelete={deleteOption}
-                />
+        <DraggableList
+        order={optionIds}
+        updateOrder={updateOptionOrder}
+        presentation="compact-center"
+        >
+          {options.map((option, index) => {
+            const optionValue = getFieldState(`options.${index}.value`);
+            const optionLabel = getFieldState(`options.${index}.label`);
+            return (
+              <div key={index}>
+                {optionValue.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionValue.error.message}
+                  </span>
+                ) : null}
+                {optionLabel.error ? (
+                  <span className="usa-error-message" role="alert">
+                    {optionLabel.error.message}
+                  </span>
+                ) : null}
+                <div className="display-flex margin-bottom-2">
+                  <input
+                    className={classnames('hide', 'usa-input', {
+                      'usa-label--error': label.error,
+                    })}
+                    id={fieldId(`options.${index}.value`)}
+                    {...register(`options.${index}.value`)}
+                    defaultValue={option.value}
+                    aria-label={`Option ${index + 1} value`}
+                  />
+                  <label
+                    htmlFor={`options-${index}.id`}
+                    className={`usa-radio__label ${styles.optionCircle}`}
+                  ></label>
+                  <input
+                    className="usa-input bg-primary-lighter"
+                    id={fieldId(`options.${index}.label`)}
+                    {...register(`options.${index}.label`)}
+                    value={option.label}
+                    onChange={e => updateOptionLabel(index, e.target.value)}
+                    aria-label={`Option ${index + 1} label`}
+                  />
+                  <PatternOptionActions
+                    optionId={option.id}
+                    onDelete={deleteOption}
+                  />
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </DraggableList>
         <button
           className={`usa-link ${styles.addMorePatternButton} margin-top-1`}
           type="button"

--- a/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/SelectDropdownPatternEdit/index.tsx
@@ -55,8 +55,8 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
   const optionIds = options.map(option => option.id as UniqueIdentifier);
 
   const updateOptionOrder = (newOrder: UniqueIdentifier[]) => {
-    const reorderedOptions = newOrder.map(id => 
-      options.find(option => option.id === id)!
+    const reorderedOptions = newOrder.map(
+      id => options.find(option => option.id === id)!
     );
     setOptions(reorderedOptions);
   };
@@ -118,9 +118,9 @@ const EditComponent = ({ pattern }: { pattern: SelectDropdownPattern }) => {
       </div>
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
         <DraggableList
-        order={optionIds}
-        updateOrder={updateOptionOrder}
-        presentation="compact-center"
+          order={optionIds}
+          updateOrder={updateOptionOrder}
+          presentation="compact-center"
         >
           {options.map((option, index) => {
             const optionValue = getFieldState(`options.${index}.value`);


### PR DESCRIPTION
*Overview*
This PR:
- adds the ability for users to drag and drop to reorder choice option fields.
- adds style: a new presentation attribute similar to "compact" called "compact-center"  

*Tests*
- updates stories to include field deletion

*Screencapture*

https://github.com/user-attachments/assets/7e0a1699-6559-41c2-9ff9-812f1386b636

References [TCKT](https://github.com/orgs/GSA-TTS/projects/17/views/8?pane=issue&itemId=104924800&issue=GSA-TTS%7Cforms%7C587)
