### PR TITLE
refactor: remove dependency on page text label in the rich text component TCKT-571

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/RichTextPatternEdit/RichTextPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RichTextPatternEdit/RichTextPatternEdit.stories.tsx
@@ -3,7 +3,6 @@ import { expect, userEvent } from '@storybook/test';
 import { within } from '@testing-library/react';
 
 import { type RichTextPattern } from '@gsa-tts/forms-core';
-import { en as message } from '@gsa-tts/forms-common/src/locales/en/app.js';
 
 import { createPatternEditStoryMeta } from '../common/story-helper.js';
 import FormEdit from '../../index.js';
@@ -36,7 +35,9 @@ export const Formatting: StoryObj<typeof FormEdit> = {
     const canvas = within(canvasElement);
 
     await userEvent.click(
-      canvas.getByText(message.patterns.richText.displayName)
+      canvas.getByText(editorText, {
+        selector: '[class*="_richTextEditorWrapper"] p',
+      })
     );
 
     const headingMap: Record<string, string> = {

--- a/packages/design/src/FormManager/FormEdit/components/RichTextPatternEdit/index.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RichTextPatternEdit/index.tsx
@@ -5,7 +5,6 @@ import { EditorContent, useEditor } from '@tiptap/react';
 import { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 
-import { enLocale as message } from '@gsa-tts/forms-common';
 import {
   type PatternId,
   type PatternMap,
@@ -76,7 +75,6 @@ const RichTextPatternEdit: PatternEditComponent<RichTextProps> = ({
         ></PatternEditForm>
       ) : (
         <div className="padding-left-3 padding-bottom-3 padding-right-3">
-          <p>{message.patterns.richText.displayName}</p>
           <RichText context={context} {...previewProps} />
         </div>
       )}


### PR DESCRIPTION
**Key changes:**
> Removed reliance on static page text labels for locating the rich text component.
> Updated Storybook tests to align with the refactored selectors.

**Relevant Ticket:**
[TCKT-571](https://github.com/GSA-TTS/forms/issues/571)